### PR TITLE
Use bcryptjs in register API

### DIFF
--- a/pages/api/register.js
+++ b/pages/api/register.js
@@ -1,5 +1,5 @@
 import prisma from "../../lib/prisma";
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).end();


### PR DESCRIPTION
## Summary
- switch register API to import bcryptjs to match installed dependency
- ensure password hashing continues to use the existing hash call

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694189cef2788324978755dd29fac67c)