### PR TITLE
Simplify admin entry serialization

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -114,14 +114,11 @@ export async function getServerSideProps(context) {
     orderBy: { createdAt: "desc" },
   });
 
-  // ✅ Convert Date objects to strings so Next.js can serialize props
+  // ✅ Convert Date objects to strings so Next.js can serialize props (both timestamps exist)
   const entries = rawEntries.map((entry) => ({
     ...entry,
     createdAt: entry.createdAt.toISOString(),
-    // Only include updatedAt if it exists in your schema
-    ...(entry.updatedAt !== undefined
-      ? { updatedAt: entry.updatedAt ? entry.updatedAt.toISOString() : null }
-      : {}),
+    updatedAt: entry.updatedAt.toISOString(),
   }));
 
   return { props: { users, entries } };


### PR DESCRIPTION
## Summary
- always serialize createdAt and updatedAt for admin entries
- update comment to reflect required timestamps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418b14e5088324966254487c0b6757)