### PR TITLE
Remove sensitive logging from NextAuth authorize

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -14,18 +14,10 @@ export const authOptions = {
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-// 🔴 ADD LOGGING HERE
-        console.log("=== AUTHORIZE CALLED ===")
-        console.log("credentials:", credentials)
-
         if (!credentials) {
-          console.log("❌ No credentials received")
           return null
         }
 
-       
-
-        console.log("✅ Login successful")
         const user = await prisma.user.findUnique({
           where: { ign: credentials.ign },
         })


### PR DESCRIPTION
## Summary
- remove debug credential logging from the NextAuth credentials authorize handler to avoid exposing secrets in logs

## Testing
- npm test -- --runInBand *(fails: jest command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941879517cc8324b1d6c64df546fa41)