### PR TITLE
Add storage search builder and saved searches

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -23,6 +23,7 @@ export default function Navbar() {
 
         <div className={`nav-links ${open ? "open" : ""}`}>
           <Link href="/" className="nav-item">Home</Link>
+          <Link href="/search-strings" className="nav-item">Search Builder</Link>
 
           {session && (
             <>

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -3,7 +3,7 @@ import { useSession } from "next-auth/react";
 import prisma from "../lib/prisma";
 import { authOptions } from "./api/auth/[...nextauth]";
 
-export default function Admin({ users, entries }) {
+export default function Admin({ users, entries, searchStrings }) {
   const { data: session } = useSession();
 
   if (!session || session.user.role !== "admin") {
@@ -81,8 +81,36 @@ export default function Admin({ users, entries }) {
               <tr key={entry.id}>
                 <td>{entry.id}</td>
                 <td>{entry.trainerName}</td>
-                <td>{entry.friendCode}</td>
+                <td>{entry.code}</td>
                 <td>{entry.owner.ign}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Saved search strings</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Title</th>
+              <th>Owner</th>
+              <th>Last updated</th>
+              <th>Query</th>
+            </tr>
+          </thead>
+          <tbody>
+            {searchStrings.map((saved) => (
+              <tr key={saved.id}>
+                <td>{saved.id}</td>
+                <td>{saved.title}</td>
+                <td>{saved.owner.ign}</td>
+                <td>{new Date(saved.updatedAt).toLocaleString()}</td>
+                <td>
+                  <code>{saved.query}</code>
+                </td>
               </tr>
             ))}
           </tbody>
@@ -114,6 +142,11 @@ export async function getServerSideProps(context) {
     orderBy: { createdAt: "desc" },
   });
 
+  const rawSearchStrings = await prisma.searchString.findMany({
+    include: { owner: { select: { ign: true } } },
+    orderBy: { updatedAt: "desc" },
+  });
+
   // ✅ Convert Date objects to strings so Next.js can serialize props (both timestamps exist)
   const entries = rawEntries.map((entry) => ({
     ...entry,
@@ -121,5 +154,11 @@ export async function getServerSideProps(context) {
     updatedAt: entry.updatedAt.toISOString(),
   }));
 
-  return { props: { users, entries } };
+  const searchStrings = rawSearchStrings.map((entry) => ({
+    ...entry,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  }));
+
+  return { props: { users, entries, searchStrings } };
 }

--- a/pages/api/search-strings/[id].js
+++ b/pages/api/search-strings/[id].js
@@ -1,0 +1,75 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import prisma from "../../../lib/prisma";
+
+function serializeSearchString(entry) {
+  return {
+    ...entry,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  };
+}
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "You must be logged in." });
+  }
+
+  const { id } = req.query;
+  const searchStringId = parseInt(id, 10);
+
+  if (Number.isNaN(searchStringId)) {
+    return res.status(400).json({ error: "Invalid search id." });
+  }
+
+  const existing = await prisma.searchString.findUnique({
+    where: { id: searchStringId },
+    include: { owner: { select: { id: true, ign: true } } },
+  });
+
+  if (!existing) {
+    return res.status(404).json({ error: "Saved search not found." });
+  }
+
+  const isAdmin = session.user.role === "admin";
+  const isOwner = existing.ownerId === session.user.id;
+
+  if (!isAdmin && !isOwner) {
+    return res.status(403).json({ error: "Access denied." });
+  }
+
+  if (req.method === "PATCH") {
+    const { title, query } = req.body;
+
+    if (!title?.trim() || !query?.trim()) {
+      return res.status(400).json({ error: "Title and search string are required." });
+    }
+
+    try {
+      const updated = await prisma.searchString.update({
+        where: { id: searchStringId },
+        data: { title: title.trim(), query: query.trim() },
+        include: { owner: { select: { id: true, ign: true } } },
+      });
+
+      return res.status(200).json(serializeSearchString(updated));
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "Failed to update search." });
+    }
+  }
+
+  if (req.method === "DELETE") {
+    try {
+      await prisma.searchString.delete({ where: { id: searchStringId } });
+      return res.status(200).json({ message: "Deleted" });
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "Failed to delete search." });
+    }
+  }
+
+  return res.status(405).json({ error: "Method not allowed." });
+}

--- a/pages/api/search-strings/index.js
+++ b/pages/api/search-strings/index.js
@@ -1,0 +1,62 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import prisma from "../../../lib/prisma";
+
+function serializeSearchString(entry) {
+  return {
+    ...entry,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  };
+}
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "You must be logged in." });
+  }
+
+  const isAdmin = session.user.role === "admin";
+
+  if (req.method === "GET") {
+    try {
+      const searchStrings = await prisma.searchString.findMany({
+        where: isAdmin ? {} : { ownerId: session.user.id },
+        include: { owner: { select: { id: true, ign: true } } },
+        orderBy: { updatedAt: "desc" },
+      });
+
+      return res.status(200).json(searchStrings.map(serializeSearchString));
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "Failed to load saved searches." });
+    }
+  }
+
+  if (req.method === "POST") {
+    const { title, query } = req.body;
+
+    if (!title?.trim() || !query?.trim()) {
+      return res.status(400).json({ error: "Title and search string are required." });
+    }
+
+    try {
+      const created = await prisma.searchString.create({
+        data: {
+          title: title.trim(),
+          query: query.trim(),
+          ownerId: session.user.id,
+        },
+        include: { owner: { select: { id: true, ign: true } } },
+      });
+
+      return res.status(201).json(serializeSearchString(created));
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: "Failed to save search." });
+    }
+  }
+
+  return res.status(405).json({ error: "Method not allowed." });
+}

--- a/pages/search-strings.js
+++ b/pages/search-strings.js
@@ -1,0 +1,349 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "./api/auth/[...nextauth]";
+import prisma from "../lib/prisma";
+
+const checkboxOptions = [
+  { key: "includeShiny", label: "Include shiny", token: "shiny" },
+  { key: "includeShadow", label: "Include shadow", token: "shadow" },
+  { key: "includePurified", label: "Include purified", token: "purified" },
+  { key: "includeLegendary", label: "Legendary", token: "legendary" },
+  { key: "includeMythical", label: "Mythical", token: "mythical" },
+  { key: "includeCostumed", label: "Costumed", token: "costumed" },
+  { key: "includeMega", label: "Mega eligible", token: "mega" },
+  { key: "favoritesOnly", label: "Favorites only", token: "favorite" },
+  { key: "excludeTraded", label: "Exclude traded", token: "!traded" },
+];
+
+function buildSearchString({
+  pokemonNames,
+  cpMin,
+  cpMax,
+  ageMin,
+  ageMax,
+  ivFilter,
+  toggles,
+}) {
+  const tokens = [];
+  const nameTokens = pokemonNames
+    .split(/[\n,]+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (nameTokens.length) {
+    tokens.push(nameTokens.join(","));
+  }
+
+  if (cpMin || cpMax) {
+    tokens.push(`cp${cpMin || ""}-${cpMax || ""}`);
+  }
+
+  if (ageMin || ageMax) {
+    tokens.push(`age${ageMin || ""}-${ageMax || ""}`);
+  }
+
+  if (ivFilter === "fourStar") tokens.push("4*");
+  if (ivFilter === "threeStar") tokens.push("3*");
+  if (ivFilter === "nundo") tokens.push("0* & !shiny");
+
+  checkboxOptions.forEach((option) => {
+    if (toggles[option.key]) {
+      tokens.push(option.token);
+    }
+  });
+
+  return tokens.join(" & ");
+}
+
+function SavedSearchList({ savedStrings, onCopy, onDelete, isAdmin }) {
+  if (!savedStrings.length) {
+    return (
+      <div className="card">
+        <p>No saved searches yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="saved-list">
+      {savedStrings.map((item) => (
+        <div key={item.id} className="card saved-item">
+          <div className="saved-header">
+            <div>
+              <h3>{item.title}</h3>
+              <p className="muted">{new Date(item.updatedAt).toLocaleString()}</p>
+              {isAdmin && item.owner && (
+                <p className="muted">Owner: {item.owner.ign}</p>
+              )}
+            </div>
+            <div className="saved-actions">
+              <button onClick={() => onCopy(item.query)}>Copy</button>
+              <button className="danger" onClick={() => onDelete(item.id)}>
+                Delete
+              </button>
+            </div>
+          </div>
+          <code className="query-preview">{item.query}</code>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function SearchStrings({ initialSavedStrings }) {
+  const { data: session } = useSession();
+  const [pokemonNames, setPokemonNames] = useState("");
+  const [cpMin, setCpMin] = useState("");
+  const [cpMax, setCpMax] = useState("");
+  const [ageMin, setAgeMin] = useState("");
+  const [ageMax, setAgeMax] = useState("");
+  const [ivFilter, setIvFilter] = useState("fourStar");
+  const [toggles, setToggles] = useState({
+    includeShiny: true,
+    includeShadow: false,
+    includePurified: false,
+    includeLegendary: false,
+    includeMythical: false,
+    includeCostumed: false,
+    includeMega: false,
+    favoritesOnly: false,
+    excludeTraded: true,
+  });
+  const [title, setTitle] = useState("Raid ready shinies");
+  const [savedStrings, setSavedStrings] = useState(initialSavedStrings || []);
+  const [status, setStatus] = useState("");
+
+  useEffect(() => {
+    setSavedStrings(initialSavedStrings || []);
+  }, [initialSavedStrings]);
+
+  const searchString = useMemo(
+    () =>
+      buildSearchString({
+        pokemonNames,
+        cpMin,
+        cpMax,
+        ageMin,
+        ageMax,
+        ivFilter,
+        toggles,
+      }),
+    [pokemonNames, cpMin, cpMax, ageMin, ageMax, ivFilter, toggles]
+  );
+
+  const handleToggle = (key) => {
+    setToggles((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleCopy = async (value) => {
+    await navigator.clipboard.writeText(value);
+    setStatus("Copied to clipboard");
+    setTimeout(() => setStatus(""), 2000);
+  };
+
+  const handleSave = async () => {
+    if (!session) {
+      setStatus("Login to save your search string.");
+      return;
+    }
+
+    if (!searchString.trim()) {
+      setStatus("Build a search string before saving.");
+      return;
+    }
+
+    const response = await fetch("/api/search-strings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, query: searchString }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      setStatus(error.error || "Unable to save search.");
+      return;
+    }
+
+    const saved = await response.json();
+    setSavedStrings((prev) => [saved, ...prev]);
+    setStatus("Saved!");
+  };
+
+  const handleDelete = async (id) => {
+    const response = await fetch(`/api/search-strings/${id}`, {
+      method: "DELETE",
+    });
+
+    if (response.ok) {
+      setSavedStrings((prev) => prev.filter((item) => item.id !== id));
+      setStatus("Deleted");
+    } else {
+      setStatus("Unable to delete search");
+    }
+  };
+
+  const isAdmin = session?.user?.role === "admin";
+
+  return (
+    <div className="container">
+      <h1>Storage Search Builder</h1>
+      <p className="muted">
+        Assemble Pokémon GO storage search strings with common filters and save
+        them for quick reuse. Only you and admins can see your saved strings.
+      </p>
+
+      <div className="card">
+        <div className="form-grid">
+          <div>
+            <label htmlFor="pokemonNames">Pokémon (comma or newline separated)</label>
+            <textarea
+              id="pokemonNames"
+              rows={4}
+              placeholder="pikachu, rayquaza, metagross"
+              value={pokemonNames}
+              onChange={(e) => setPokemonNames(e.target.value)}
+            />
+          </div>
+          <div className="dual-inputs">
+            <div>
+              <label htmlFor="cpMin">CP min</label>
+              <input
+                id="cpMin"
+                type="number"
+                min="0"
+                value={cpMin}
+                onChange={(e) => setCpMin(e.target.value)}
+              />
+            </div>
+            <div>
+              <label htmlFor="cpMax">CP max</label>
+              <input
+                id="cpMax"
+                type="number"
+                min="0"
+                value={cpMax}
+                onChange={(e) => setCpMax(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="dual-inputs">
+            <div>
+              <label htmlFor="ageMin">Age min (days)</label>
+              <input
+                id="ageMin"
+                type="number"
+                min="0"
+                value={ageMin}
+                onChange={(e) => setAgeMin(e.target.value)}
+              />
+            </div>
+            <div>
+              <label htmlFor="ageMax">Age max (days)</label>
+              <input
+                id="ageMax"
+                type="number"
+                min="0"
+                value={ageMax}
+                onChange={(e) => setAgeMax(e.target.value)}
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="ivFilter">IV Filter</label>
+            <select
+              id="ivFilter"
+              value={ivFilter}
+              onChange={(e) => setIvFilter(e.target.value)}
+            >
+              <option value="fourStar">4★ (Hundo)</option>
+              <option value="threeStar">3★+</option>
+              <option value="nundo">0★ non-shiny</option>
+              <option value="">No IV filter</option>
+            </select>
+          </div>
+          <div className="checkboxes">
+            {checkboxOptions.map((option) => (
+              <label key={option.key} className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={toggles[option.key]}
+                  onChange={() => handleToggle(option.key)}
+                />
+                {option.label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="result-card">
+          <div className="result-header">
+            <div>
+              <h3>Generated search string</h3>
+              <p className="muted">
+                Combine filters to mirror https://pogosearchgenerator.com/ behaviour.
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={!searchString}
+              onClick={() => handleCopy(searchString)}
+            >
+              Copy
+            </button>
+          </div>
+          <code className="query-preview">{searchString || "Add filters to build a search."}</code>
+        </div>
+
+        <div className="save-row">
+          <div>
+            <label htmlFor="title">Save as</label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="My Rocket hunt"
+            />
+          </div>
+          <button type="button" onClick={handleSave}>
+            Save search
+          </button>
+        </div>
+
+        {status && <p className="status">{status}</p>}
+      </div>
+
+      <h2>Saved searches</h2>
+      <SavedSearchList
+        savedStrings={savedStrings}
+        onCopy={handleCopy}
+        onDelete={handleDelete}
+        isAdmin={isAdmin}
+      />
+    </div>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const session = await getServerSession(context.req, context.res, authOptions);
+
+  if (!session) {
+    return { props: { initialSavedStrings: [] } };
+  }
+
+  const isAdmin = session.user.role === "admin";
+  const searchStrings = await prisma.searchString.findMany({
+    where: isAdmin ? {} : { ownerId: session.user.id },
+    include: { owner: { select: { id: true, ign: true } } },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  const initialSavedStrings = searchStrings.map((entry) => ({
+    ...entry,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  }));
+
+  return { props: { initialSavedStrings } };
+}

--- a/prisma/migrations/20251216170915_add_search_strings/migration.sql
+++ b/prisma/migrations/20251216170915_add_search_strings/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "SearchString" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "query" TEXT NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SearchString_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT,
+    "ign" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'user'
+);
+INSERT INTO "new_User" ("id", "ign", "name", "password", "role") SELECT "id", "ign", "name", "password", "role" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_ign_key" ON "User"("ign");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   password String
   entries  Entry[] // back-relation to Entry
   role     String  @default("user")
+  searchStrings SearchString[]
 }
 
 model Entry {
@@ -24,4 +25,14 @@ model Entry {
   owner       User     @relation(fields: [ownerId], references: [id])
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+model SearchString {
+  id        Int      @id @default(autoincrement())
+  title     String
+  query     String
+  ownerId   Int
+  owner     User     @relation(fields: [ownerId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -65,6 +65,100 @@ label {
   display: block;
 }
 
+.muted {
+  color: #8b949e;
+  margin-top: 4px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.dual-inputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  padding-top: 8px;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.result-card {
+  background: #0d1117;
+  border: 1px dashed #30363d;
+  padding: 16px;
+  border-radius: 8px;
+  margin-top: 12px;
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.query-preview {
+  display: block;
+  background: #161b22;
+  border: 1px solid #30363d;
+  padding: 12px;
+  border-radius: 8px;
+  color: #9ecbff;
+  white-space: pre-wrap;
+}
+
+.save-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.save-row input {
+  min-width: 260px;
+}
+
+.status {
+  margin-top: 10px;
+  color: #a5d6ff;
+}
+
+.saved-list {
+  display: grid;
+  gap: 12px;
+}
+
+.saved-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.saved-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.danger {
+  background: #b62324;
+}
+
 /* Responsive rules */
 @media (max-width: 600px) {
   .container {
@@ -75,6 +169,15 @@ label {
   }
   button {
     width: 100%;
+  }
+
+  .dual-inputs {
+    grid-template-columns: 1fr;
+  }
+
+  .save-row {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 /* NAVBAR */


### PR DESCRIPTION
## Summary
- add a Prisma SearchString model and migration for storing user-specific storage searches
- create API routes to create, list, update, and delete search strings with owner/admin access control
- build a storage search generator page with save/copy UX, admin visibility, navigation link, and supporting styles

## Testing
- npm test *(fails: jest binary unavailable in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941919036c48324905c4224757d6486)