### PR TITLE
Replace register page with React form

### DIFF
--- a/pages/register.js
+++ b/pages/register.js
@@ -1,49 +1,96 @@
-import prisma from "../../../lib/prisma"
-import bcrypt from "bcryptjs"
+import Link from "next/link"
+import { useState } from "react"
+import { getSession } from "next-auth/react"
+import { useRouter } from "next/router"
 
-export default async function handler(req, res) {
-  if (req.method !== "POST") {
-    return res.status(405).json({ error: "Method not allowed" })
-  }
+export default function Register() {
+  const [name, setName] = useState("")
+  const [ign, setIgn] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState("")
+  const router = useRouter()
 
-  const { name, ign, password } = req.body
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError("")
+    setSuccess("")
 
-  if (!name || !ign || !password) {
-    return res.status(400).json({ error: "Missing required fields" })
-  }
-
-  if (password.length < 8) {
-    return res
-      .status(400)
-      .json({ error: "Password must be at least 8 characters" })
-  }
-
-  try {
-    // Check if IGN already exists
-    const existingUser = await prisma.user.findUnique({
-      where: { ign },
+    const res = await fetch("/api/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, ign, password }),
     })
 
-    if (existingUser) {
-      return res.status(409).json({ error: "IGN already registered" })
+    const data = await res.json()
+
+    if (!res.ok) {
+      setError(data.error || "Registration failed")
+      return
     }
 
-    // Hash password
-    const hashedPassword = await bcrypt.hash(password, 10)
-
-    // Create user
-    await prisma.user.create({
-      data: {
-        name,
-        ign,
-        password: hashedPassword,
-        role: "user",
-      },
-    })
-
-    return res.status(201).json({ success: true })
-  } catch (err) {
-    console.error("REGISTER ERROR:", err)
-    return res.status(500).json({ error: "Internal server error" })
+    setSuccess("Registration successful! Please sign in.")
+    setPassword("")
+    setName("")
+    setIgn("")
+    setTimeout(() => router.push("/login"), 1000)
   }
+
+  return (
+    <div className="login-container">
+      <h1>Register</h1>
+
+      <form onSubmit={handleSubmit}>
+        <label>
+          Name (optional)
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Optional"
+          />
+        </label>
+
+        <label>
+          In-Game Name
+          <input
+            type="text"
+            value={ign}
+            onChange={(e) => setIgn(e.target.value)}
+            required
+          />
+        </label>
+
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+
+        <button type="submit">Register</button>
+
+        {error && <p style={{ color: "red" }}>{error}</p>}
+        {success && <p style={{ color: "green" }}>{success}</p>}
+      </form>
+
+      <p style={{ marginTop: "1rem" }}>
+        Already have an account? <Link href="/login">Login</Link>
+      </p>
+    </div>
+  )
+}
+
+export async function getServerSideProps(context) {
+  const session = await getSession(context)
+  if (session) {
+    return {
+      redirect: { destination: "/", permanent: false },
+    }
+  }
+
+  return { props: {} }
 }


### PR DESCRIPTION
## Summary
- replace the register page with a React form that posts to the auth register API
- add logged-in redirect protection and link to the login page using Next.js Link

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b36a9754832493b3081ecad2da3a)