### PR TITLE
Enable admin entry management and use Turbopack dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3000 -H 0.0.0.0",
+    "dev": "next dev --turbo -p 3000 -H 0.0.0.0",
     "build": "next build",
     "start": "next start -p 3000 -H 0.0.0.0",
     "lint": "next lint",

--- a/pages/api/admin/entries/[id].js
+++ b/pages/api/admin/entries/[id].js
@@ -15,10 +15,15 @@ export default async function handler(req, res) {
   }
 
   if (req.method === "PUT") {
-    const { title, code } = req.body;
+    const { trainerName, friendCode } = req.body;
+
+    if (!trainerName || !friendCode) {
+      return res.status(400).json({ message: "Missing fields" });
+    }
+
     const updated = await prisma.entry.update({
       where: { id: Number(id) },
-      data: { title, code },
+      data: { trainerName, code: friendCode },
     });
     return res.json(updated);
   }

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -35,7 +35,7 @@ export default async function handler(req, res) {
     try {
       const updatedEntry = await prisma.entry.update({
         where: { id: entryId },
-        data: { trainerName, friendCode },
+        data: { trainerName, code: friendCode },
       });
       res.status(200).json(updatedEntry);
     } catch (err) {

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -20,7 +20,7 @@ async function main() {
     },
   })
 
-  console.log("✅ Seeded user:", { ign, passwordPlain })
+  console.log("✅ Seeded default user", ign)
 }
 
 main()


### PR DESCRIPTION
## Summary
- add inline admin controls to edit and delete friend code entries
- fix entry update APIs to persist trainer names and codes correctly
- remove sensitive seed logging and enable Turbopack for local development

## Testing
- npm test *(fails: Jest cannot parse prisma/package.json in vendor assets)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cda3ca9c8324b07c88da2acc13d0)