### PR TITLE
Persist NextAuth secret and allow additional dev origins

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -1,4 +1,30 @@
 import crypto from "crypto"
+import fs from "fs"
+import path from "path"
+
+const DEFAULT_SECRET = "your-secret-key-change-in-production"
+const SECRET_FILE = path.join(process.cwd(), ".nextauth-secret")
+
+function readPersistedSecret() {
+  try {
+    if (fs.existsSync(SECRET_FILE)) {
+      const stored = fs.readFileSync(SECRET_FILE, "utf8").trim()
+      if (stored) return stored
+    }
+  } catch (error) {
+    console.warn("Unable to read persisted NextAuth secret", error)
+  }
+
+  return null
+}
+
+function persistSecret(secret) {
+  try {
+    fs.writeFileSync(SECRET_FILE, secret, { mode: 0o600 })
+  } catch (error) {
+    console.warn("Unable to persist NextAuth secret", error)
+  }
+}
 
 function normalizeUrl(url) {
   if (!url) return null
@@ -31,11 +57,18 @@ export function ensureNextAuthUrl() {
 
 export function getNextAuthSecret() {
   const secret = process.env.NEXTAUTH_SECRET
-  if (secret && secret !== "your-secret-key-change-in-production") {
+  if (secret && secret !== DEFAULT_SECRET) {
     return secret
+  }
+
+  const persisted = readPersistedSecret()
+  if (persisted) {
+    process.env.NEXTAUTH_SECRET = persisted
+    return persisted
   }
 
   const generated = crypto.randomBytes(32).toString("hex")
   process.env.NEXTAUTH_SECRET = generated
+  persistSecret(generated)
   return generated
 }

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,8 @@ const nextConfig = {
     "http://192.168.2.254:3000",
     "http://localhost:3000",
     "https://dev.leighpogo.co.uk",
+    "https://leighpogo.co.uk",
+    "https://www.leighpogo.co.uk",
   ],
 };
 


### PR DESCRIPTION
## Summary
- persist the NextAuth secret across restarts by caching it in a local file when an explicit secret is not provided
- expand allowedDevOrigins to include the production domains to prevent blocked cross-origin requests

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694275c2d8f48324bfb2b9eb09d92018)