### PR TITLE
Add admin and user password reset flows

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -29,6 +29,7 @@ export default function Navbar() {
           {session && (
             <>
               <Link href="/entries/add" className="nav-item">Add Entry</Link>
+              <Link href="/account" className="nav-item">Account</Link>
               {isAdmin && <Link href="/admin" className="nav-item">Admin Panel</Link>}
               <button
                 className="nav-btn"

--- a/pages/account.js
+++ b/pages/account.js
@@ -1,0 +1,98 @@
+import { useState } from "react"
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "./api/auth/[...nextauth]"
+
+export default function Account() {
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [status, setStatus] = useState({ type: "", message: "" })
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setStatus({ type: "", message: "" })
+
+    if (newPassword !== confirmPassword) {
+      setStatus({ type: "error", message: "New passwords do not match" })
+      return
+    }
+
+    const res = await fetch("/api/auth/change-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currentPassword, newPassword }),
+    })
+
+    const data = await res.json()
+
+    if (!res.ok) {
+      setStatus({ type: "error", message: data.error || "Unable to update password" })
+      return
+    }
+
+    setStatus({ type: "success", message: "Password updated successfully" })
+    setCurrentPassword("")
+    setNewPassword("")
+    setConfirmPassword("")
+  }
+
+  return (
+    <div className="container">
+      <h1>Account settings</h1>
+
+      <section>
+        <h2>Change password</h2>
+        <form onSubmit={handleSubmit} className="stack">
+          <label>
+            Current password
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              required
+            />
+          </label>
+
+          <label>
+            New password
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+            />
+          </label>
+
+          <label>
+            Confirm new password
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+            />
+          </label>
+
+          <button type="submit">Update password</button>
+          {status.message && (
+            <p style={{ color: status.type === "error" ? "red" : "green" }}>
+              {status.message}
+            </p>
+          )}
+        </form>
+      </section>
+    </div>
+  )
+}
+
+export async function getServerSideProps(context) {
+  const session = await getServerSession(context.req, context.res, authOptions)
+
+  if (!session) {
+    return {
+      redirect: { destination: "/login", permanent: false },
+    }
+  }
+
+  return { props: {} }
+}

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -10,6 +10,7 @@ export default function Admin({ users, entries, searchStrings }) {
   const [entryList, setEntryList] = useState(entries);
   const [editingEntryId, setEditingEntryId] = useState(null);
   const [editForm, setEditForm] = useState({ trainerName: "", friendCode: "" });
+  const [passwordResets, setPasswordResets] = useState({});
 
   if (!session || session.user.role !== "admin") {
     return <p>Access denied</p>;
@@ -22,6 +23,29 @@ export default function Admin({ users, entries, searchStrings }) {
       body: JSON.stringify({ role: newRole }),
     });
     location.reload(); // simple way to refresh page
+  };
+
+  const handlePasswordReset = async (id) => {
+    const newPassword = passwordResets[id] ?? "";
+
+    if (newPassword.length < 8) {
+      alert("Password must be at least 8 characters long");
+      return;
+    }
+
+    const res = await fetch(`/api/admin/users/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password: newPassword }),
+    });
+
+    if (!res.ok) {
+      alert("Failed to reset password");
+      return;
+    }
+
+    alert("Password updated");
+    setPasswordResets((current) => ({ ...current, [id]: "" }));
   };
 
   const handleDelete = async (id) => {
@@ -85,6 +109,7 @@ export default function Admin({ users, entries, searchStrings }) {
               <th>ID</th>
               <th>IGN</th>
               <th>Role</th>
+              <th>Reset password</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -94,6 +119,22 @@ export default function Admin({ users, entries, searchStrings }) {
                 <td>{user.id}</td>
                 <td>{user.ign}</td>
                 <td>{user.role}</td>
+                <td>
+                  <input
+                    type="password"
+                    placeholder="New password"
+                    value={passwordResets[user.id] ?? ""}
+                    onChange={(e) =>
+                      setPasswordResets((current) => ({
+                        ...current,
+                        [user.id]: e.target.value,
+                      }))
+                    }
+                  />
+                  <button onClick={() => handlePasswordReset(user.id)}>
+                    Save
+                  </button>
+                </td>
                 <td>
                   {user.role === "user" ? (
                     <button onClick={() => handleRoleChange(user.id, "admin")}>

--- a/pages/api/admin/users/[id].js
+++ b/pages/api/admin/users/[id].js
@@ -1,32 +1,54 @@
-import { getServerSession } from "next-auth/next";
-import prisma from "../../../../lib/prisma";
-import { authOptions } from "../../auth/[...nextauth].js";
+import bcrypt from "bcryptjs"
+import { getServerSession } from "next-auth/next"
+import prisma from "../../../../lib/prisma"
+import { authOptions } from "../../auth/[...nextauth].js"
 
 export default async function handler(req, res) {
-  const session = await getServerSession(req, res, authOptions);
+  const session = await getServerSession(req, res, authOptions)
 
   if (!session || session.user.role !== "admin") {
-    return res.status(403).json({ error: "Access denied" });
+    return res.status(403).json({ error: "Access denied" })
   }
 
-  const userId = parseInt(req.query.id);
+  const userId = parseInt(req.query.id)
 
   if (req.method === "PATCH") {
-    // Promote or demote user
-    const { role } = req.body;
-    if (!role || !["user", "admin"].includes(role)) {
-      return res.status(400).json({ error: "Invalid role" });
+    const { role, password } = req.body
+
+    const updates = {}
+
+    if (role !== undefined) {
+      if (!role || !["user", "admin"].includes(role)) {
+        return res.status(400).json({ error: "Invalid role" })
+      }
+      updates.role = role
+    }
+
+    if (password !== undefined) {
+      if (typeof password !== "string" || password.length < 8) {
+        return res
+          .status(400)
+          .json({ error: "Password must be at least 8 characters" })
+      }
+
+      updates.password = await bcrypt.hash(password, 10)
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res
+        .status(400)
+        .json({ error: "No valid updates provided" })
     }
 
     try {
       const updatedUser = await prisma.user.update({
         where: { id: userId },
-        data: { role },
-      });
-      res.status(200).json(updatedUser);
+        data: updates,
+      })
+      res.status(200).json(updatedUser)
     } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Failed to update user" });
+      console.error(err)
+      res.status(500).json({ error: "Failed to update user" })
     }
 
   } else if (req.method === "DELETE") {

--- a/pages/api/auth/change-password.js
+++ b/pages/api/auth/change-password.js
@@ -1,0 +1,48 @@
+import bcrypt from "bcryptjs"
+import { getServerSession } from "next-auth/next"
+import prisma from "../../../lib/prisma"
+import { authOptions } from "./[...nextauth]"
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" })
+  }
+
+  const session = await getServerSession(req, res, authOptions)
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Unauthorized" })
+  }
+
+  const { currentPassword, newPassword } = req.body ?? {}
+
+  if (!currentPassword || !newPassword) {
+    return res.status(400).json({ error: "Current and new passwords are required" })
+  }
+
+  if (typeof newPassword !== "string" || newPassword.length < 8) {
+    return res
+      .status(400)
+      .json({ error: "New password must be at least 8 characters long" })
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } })
+
+  if (!user) {
+    return res.status(404).json({ error: "User not found" })
+  }
+
+  const isValid = await bcrypt.compare(currentPassword, user.password)
+
+  if (!isValid) {
+    return res.status(401).json({ error: "Current password is incorrect" })
+  }
+
+  const hashedPassword = await bcrypt.hash(newPassword, 10)
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { password: hashedPassword },
+  })
+
+  return res.status(200).json({ success: true })
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -76,6 +76,12 @@ label {
   gap: 16px;
 }
 
+.stack {
+  display: grid;
+  gap: 12px;
+  max-width: 460px;
+}
+
 .dual-inputs {
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary
- allow admins to set new passwords for users from the admin panel
- provide a user-facing account page to change passwords with validation
- add supporting API endpoints and styling updates for password reset flows

## Testing
- npm test *(fails: jest cannot parse prisma/package.json that already contains invalid JSON)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d7dccd98832484c6abc88040dfb0)