### PR TITLE
Fix login page csrf prop shape

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -121,8 +121,7 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
-      props: { csrfToken: (await getCsrfToken(context)) ?? null },
-
+      csrfToken: (await getCsrfToken(context)) ?? null,
     },
   }
 }


### PR DESCRIPTION
## Summary
- return the csrf token directly from login getServerSideProps
- ensure the login page receives the expected csrfToken prop for authentication

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694315bec58883249ea95aa90d0329a1)