### PR TITLE
Adjust middleware matcher to exclude login path

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -8,6 +8,6 @@ export default withAuth({
 
 export const config = {
   matcher: [
-    "/((?!login|register|api/auth|_next/static|_next/image|favicon.ico).*)",
+    /^\/((?!login$|login\/|register|api\/auth|_next\/static|_next\/image|favicon\.ico).*)/,
   ],
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -121,8 +121,7 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
-      props: { csrfToken: (await getCsrfToken(context)) ?? null },
-
+      csrfToken: (await getCsrfToken(context)) ?? null,
     },
   }
 }


### PR DESCRIPTION
## Summary
- update auth middleware matcher to explicitly skip the login route and prevent redirect loops

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694315bec58883249ea95aa90d0329a1)