### PR TITLE
Add sprites to Pokédex entries

### DIFF
--- a/pages/pokedex.js
+++ b/pages/pokedex.js
@@ -2,6 +2,21 @@ import { useEffect, useMemo, useState } from "react"
 import { useSession } from "next-auth/react"
 import pokedexByRegion, { flatPokemonList } from "../lib/pokedexData"
 
+const buildSpriteUrl = (name) => {
+  const slug = name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/♀/g, "-f")
+    .replace(/♂/g, "-m")
+    .replace(/[\u2019']/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .replace(/-{2,}/g, "-")
+
+  return `https://img.pokemondb.net/sprites/home/normal/2x/${slug}.jpg`
+}
+
 function PokedexRegion({ region, caughtSet, onToggle }) {
   const [isOpen, setIsOpen] = useState(true)
   const caughtCount = useMemo(
@@ -43,8 +58,16 @@ function PokedexRegion({ region, caughtSet, onToggle }) {
                   checked={checked}
                   onChange={() => onToggle(pokemon.dexNumber)}
                 />
-                <span className="dex-number">#{pokemon.dexNumber.toString().padStart(3, "0")}</span>
-                <span className="pokemon-name">{pokemon.name}</span>
+                <img
+                  src={buildSpriteUrl(pokemon.name)}
+                  alt={pokemon.name}
+                  className="pokemon-sprite"
+                  loading="lazy"
+                />
+                <div className="pokemon-info">
+                  <span className="dex-number">#{pokemon.dexNumber.toString().padStart(3, "0")}</span>
+                  <span className="pokemon-name">{pokemon.name}</span>
+                </div>
               </label>
             )
           })}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -364,12 +364,18 @@ label {
 .pokedex-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   padding: 10px;
   border: 1px solid #30363d;
   border-radius: 8px;
   background: #0d1117;
   transition: border 0.15s ease, background 0.15s ease;
+}
+
+.pokemon-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .pokedex-item.caught {
@@ -385,6 +391,16 @@ label {
 
 .pokemon-name {
   font-weight: 700;
+}
+
+.pokemon-sprite {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  background: #0a0f14;
+  border: 1px solid #1f2933;
+  border-radius: 8px;
+  padding: 6px;
 }
 
 /* Mobile Nav */


### PR DESCRIPTION
## Summary
- add a sprite URL builder that normalizes Pokémon names for the PokéDB image host
- display each Pokémon’s sprite alongside its dex number and name in the Pokédex grid
- adjust Pokédex styling to accommodate the new sprite and text layout

## Testing
- npm test -- --runInBand *(fails: prisma/package.json contains invalid JSON prior to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e6477cc4832484851a5b4d51e111)