### PR TITLE
Display trainer names for friend codes

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -89,7 +89,7 @@ export default function Home({ entries }) {
           <ul>
             {entryList.map((entry) => (
               <li key={entry.id}>
-                <strong>{entry.owner.ign}</strong>: {entry.code}
+                <strong>{entry.trainerName}</strong>: {entry.code}
               </li>
             ))}
           </ul>
@@ -99,17 +99,10 @@ export default function Home({ entries }) {
   )
 }
 
-// Fetch all entries and include the owner's IGN
+// Fetch all entries for server-side rendering
 export async function getServerSideProps() {
   const entries = await prisma.entry.findMany({
     orderBy: { createdAt: "desc" },
-    include: {
-      owner: {
-        select: {
-          ign: true, // Only select the IGN field
-        },
-      },
-    },
   })
 
   // Serialize dates to strings for JSON


### PR DESCRIPTION
## Summary
- show each friend code with its trainer name instead of the owner's IGN
- simplify server-side entry fetch now that owner data is unused

## Testing
- npm test -- --runInBand (fails: Prisma could not open the database file)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69442196ad2c8324b4e6c5b13b98c2d5)