### PR TITLE
Update team badges to use Pokémon HOME icons

### DIFF
--- a/components/TeamBadge.js
+++ b/components/TeamBadge.js
@@ -1,23 +1,40 @@
 import React from "react"
 
 const TEAM_METADATA = {
-  INSTINCT: { label: "Instinct", color: "#f7d02c", symbol: "⚡" },
-  MYSTIC: { label: "Mystic", color: "#3d7dca", symbol: "❄️" },
-  VALOR: { label: "Valor", color: "#e53e3e", symbol: "🔥" },
+  NONE: {
+    label: "No Team",
+    color: "#9CA3AF",
+    icon:
+      "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS_OS_128/team/0.png",
+  },
+  INSTINCT: {
+    label: "Instinct",
+    color: "#f7d02c",
+    icon:
+      "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS_OS_128/team/3.png",
+  },
+  MYSTIC: {
+    label: "Mystic",
+    color: "#3d7dca",
+    icon:
+      "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS_OS_128/team/1.png",
+  },
+  VALOR: {
+    label: "Valor",
+    color: "#e53e3e",
+    icon:
+      "https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS_OS_128/team/2.png",
+  },
 }
 
 export default function TeamBadge({ team }) {
-  if (!team) return null
-
-  const normalized = team.toUpperCase()
-  const meta = TEAM_METADATA[normalized]
-
-  if (!meta) return null
+  const normalized = team ? team.toUpperCase() : "NONE"
+  const meta = TEAM_METADATA[normalized] || TEAM_METADATA.NONE
 
   return (
     <span className="team-badge" title={`${meta.label} team`}>
       <span className="team-icon" style={{ backgroundColor: meta.color }} aria-hidden="true">
-        {meta.symbol}
+        <img src={meta.icon} alt={`${meta.label} icon`} />
       </span>
       <span className="team-label">{meta.label}</span>
     </span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -225,8 +225,14 @@ label {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  font-size: 14px;
   box-shadow: 0 0 0 2px #0d1117;
+}
+
+.team-icon img {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  object-fit: contain;
 }
 
 .team-label {


### PR DESCRIPTION
## Summary
- switch team badges to Pokémon HOME icon set with Mystic, Valor, Instinct mappings and a default no-team badge
- render badges with image icons and styling tweaks so missing or unknown teams still display a default badge

## Testing
- npm test -- --runInBand *(fails: Prisma cannot open the database file in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443124e888832497e04cce0bef354d)