### PR TITLE
Allow editing friend code teams

### DIFF
--- a/__tests__/api/entries.test.js
+++ b/__tests__/api/entries.test.js
@@ -22,12 +22,22 @@ const handler = require("../../pages/api/entries").default;
 const ensureSchema = async () => {
   await prisma.$executeRawUnsafe("PRAGMA foreign_keys = ON");
   await prisma.$executeRawUnsafe(`
+    DROP TABLE IF EXISTS "Entry";
+  `);
+
+  await prisma.$executeRawUnsafe(`
+    DROP TABLE IF EXISTS "User";
+  `);
+
+  await prisma.$executeRawUnsafe(`
     CREATE TABLE IF NOT EXISTS "User" (
       "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       "name" TEXT,
       "ign" TEXT NOT NULL UNIQUE,
       "password" TEXT NOT NULL,
-      "role" TEXT NOT NULL DEFAULT 'user'
+      "role" TEXT NOT NULL DEFAULT 'user',
+      "friendCode" TEXT,
+      "team" TEXT NOT NULL DEFAULT 'MYSTIC'
     )
   `);
 
@@ -36,6 +46,7 @@ const ensureSchema = async () => {
       "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       "trainerName" TEXT NOT NULL,
       "code" TEXT NOT NULL,
+      "team" TEXT NOT NULL DEFAULT 'MYSTIC',
       "ownerId" INTEGER NOT NULL,
       "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
       "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/pages/account.js
+++ b/pages/account.js
@@ -4,14 +4,13 @@ import { authOptions } from "./api/auth/[...nextauth]"
 import prisma from "../lib/prisma"
 import TeamBadge from "../components/TeamBadge"
 
-export default function Account({ entry }) {
+export default function Account({ entries }) {
   const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [status, setStatus] = useState({ type: "", message: "" })
-  const [friendCode, setFriendCode] = useState(entry?.friendCode || "")
-  const [team, setTeam] = useState(entry?.team || "MYSTIC")
-  const [profileStatus, setProfileStatus] = useState({ type: "", message: "" })
+  const [ownedEntries, setOwnedEntries] = useState(entries || [])
+  const [entryStatuses, setEntryStatuses] = useState({})
 
   const handlePasswordSubmit = async (event) => {
     event.preventDefault()
@@ -41,30 +40,47 @@ export default function Account({ entry }) {
     setConfirmPassword("")
   }
 
-  const handleProfileSubmit = async (event) => {
-    event.preventDefault()
-    setProfileStatus({ type: "", message: "" })
+  const handleEntryChange = (id, field, value) => {
+    setOwnedEntries((current) =>
+      current.map((entry) => (entry.id === id ? { ...entry, [field]: value } : entry))
+    )
+  }
 
-    const res = await fetch("/api/account", {
-      method: "PUT",
+  const handleEntrySubmit = async (event, entryId) => {
+    event.preventDefault()
+    setEntryStatuses((prev) => ({ ...prev, [entryId]: { type: "", message: "" } }))
+
+    const entry = ownedEntries.find((item) => item.id === entryId)
+    if (!entry) return
+
+    const res = await fetch(`/api/entries/${entryId}`, {
+      method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ friendCode, team }),
+      body: JSON.stringify({
+        trainerName: entry.trainerName,
+        friendCode: entry.code,
+        team: entry.team,
+      }),
     })
 
     const data = await res.json()
 
     if (!res.ok) {
-      setProfileStatus({
-        type: "error",
-        message: data.error || "Unable to update trainer profile",
-      })
+      setEntryStatuses((prev) => ({
+        ...prev,
+        [entryId]: { type: "error", message: data.error || "Unable to update entry" },
+      }))
       return
     }
 
-    if (data.team) setTeam(data.team)
-    if (typeof data.friendCode === "string") setFriendCode(data.friendCode)
+    setOwnedEntries((current) =>
+      current.map((item) => (item.id === entryId ? { ...item, ...data } : item))
+    )
 
-    setProfileStatus({ type: "success", message: "Trainer profile updated" })
+    setEntryStatuses((prev) => ({
+      ...prev,
+      [entryId]: { type: "success", message: "Trainer entry updated" },
+    }))
   }
 
   return (
@@ -72,36 +88,56 @@ export default function Account({ entry }) {
       <h1>Account settings</h1>
 
       <section>
-        <h2>Trainer profile</h2>
-        <form onSubmit={handleProfileSubmit} className="stack">
-          <label>
-            Team
-            <select value={team} onChange={(e) => setTeam(e.target.value)}>
-              <option value="INSTINCT">Instinct (Yellow)</option>
-              <option value="MYSTIC">Mystic (Blue)</option>
-              <option value="VALOR">Valor (Red)</option>
-            </select>
-          </label>
+        <h2>Your friend codes</h2>
+        {ownedEntries.length === 0 ? (
+          <p className="muted">No friend codes added yet.</p>
+        ) : (
+          <div className="stack">
+            {ownedEntries.map((entry) => (
+              <form key={entry.id} onSubmit={(event) => handleEntrySubmit(event, entry.id)} className="stack">
+                <label>
+                  Trainer name
+                  <input type="text" value={entry.trainerName} disabled />
+                </label>
 
-          <label>
-            Friend code
-            <input
-              type="text"
-              value={friendCode}
-              onChange={(e) => setFriendCode(e.target.value)}
-              placeholder="0000 0000 0000"
-            />
-          </label>
+                <label>
+                  Team
+                  <select
+                    value={entry.team}
+                    onChange={(e) => handleEntryChange(entry.id, "team", e.target.value)}
+                  >
+                    <option value="INSTINCT">Instinct (Yellow)</option>
+                    <option value="MYSTIC">Mystic (Blue)</option>
+                    <option value="VALOR">Valor (Red)</option>
+                  </select>
+                </label>
 
-          <TeamBadge team={team} />
+                <label>
+                  Friend code
+                  <input
+                    type="text"
+                    value={entry.code}
+                    onChange={(e) => handleEntryChange(entry.id, "code", e.target.value)}
+                    placeholder="0000 0000 0000"
+                  />
+                </label>
 
-          <button type="submit">Save profile</button>
-          {profileStatus.message && (
-            <p style={{ color: profileStatus.type === "error" ? "red" : "green" }}>
-              {profileStatus.message}
-            </p>
-          )}
-        </form>
+                <TeamBadge team={entry.team} />
+
+                <button type="submit">Save entry</button>
+                {entryStatuses[entry.id]?.message && (
+                  <p
+                    style={{
+                      color: entryStatuses[entry.id].type === "error" ? "red" : "green",
+                    }}
+                  >
+                    {entryStatuses[entry.id].message}
+                  </p>
+                )}
+              </form>
+            ))}
+          </div>
+        )}
       </section>
 
       <section>
@@ -158,17 +194,13 @@ export async function getServerSideProps(context) {
     }
   }
 
-  const latestEntry = await prisma.entry.findFirst({
+  const ownedEntries = await prisma.entry.findMany({
     where: { ownerId: session.user.id },
     orderBy: { createdAt: "desc" },
-    select: { trainerName: true, code: true, team: true },
+    select: { id: true, trainerName: true, code: true, team: true },
   })
 
   return {
-    props: {
-      entry: latestEntry
-        ? { friendCode: latestEntry.code, team: latestEntry.team, trainerName: latestEntry.trainerName }
-        : null,
-    },
+    props: { entries: ownedEntries },
   }
 }

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -9,7 +9,7 @@ export default function Admin({ users, entries, searchStrings }) {
 
   const [entryList, setEntryList] = useState(entries);
   const [editingEntryId, setEditingEntryId] = useState(null);
-  const [editForm, setEditForm] = useState({ trainerName: "", friendCode: "" });
+  const [editForm, setEditForm] = useState({ trainerName: "", friendCode: "", team: "MYSTIC" });
   const [passwordResets, setPasswordResets] = useState({});
 
   // Sidebar "accordion" state (matches your production look: green buttons on the left)
@@ -67,12 +67,12 @@ export default function Admin({ users, entries, searchStrings }) {
 
   const startEdit = (entry) => {
     setEditingEntryId(entry.id);
-    setEditForm({ trainerName: entry.trainerName, friendCode: entry.code });
+    setEditForm({ trainerName: entry.trainerName, friendCode: entry.code, team: entry.team });
   };
 
   const cancelEdit = () => {
     setEditingEntryId(null);
-    setEditForm({ trainerName: "", friendCode: "" });
+    setEditForm({ trainerName: "", friendCode: "", team: "MYSTIC" });
   };
 
   const handleEntrySave = async (id) => {
@@ -143,6 +143,7 @@ export default function Admin({ users, entries, searchStrings }) {
                     <th>ID</th>
                     <th>Trainer</th>
                     <th>Friend Code</th>
+                    <th>Team</th>
                     <th>Owner IGN</th>
                     <th>Actions</th>
                   </tr>
@@ -181,6 +182,22 @@ export default function Admin({ users, entries, searchStrings }) {
                           />
                         ) : (
                           entry.code
+                        )}
+                      </td>
+                      <td>
+                        {editingEntryId === entry.id ? (
+                          <select
+                            value={editForm.team}
+                            onChange={(e) =>
+                              setEditForm((prev) => ({ ...prev, team: e.target.value }))
+                            }
+                          >
+                            <option value="INSTINCT">Instinct (Yellow)</option>
+                            <option value="MYSTIC">Mystic (Blue)</option>
+                            <option value="VALOR">Valor (Red)</option>
+                          </select>
+                        ) : (
+                          entry.team
                         )}
                       </td>
                       <td>{entry.owner?.ign}</td>

--- a/pages/api/admin/entries/[id].js
+++ b/pages/api/admin/entries/[id].js
@@ -15,15 +15,41 @@ export default async function handler(req, res) {
   }
 
   if (req.method === "PUT") {
-    const { trainerName, friendCode } = req.body;
+    const { trainerName, friendCode, team } = req.body;
+    const updates = {};
+    const validTeams = ["INSTINCT", "MYSTIC", "VALOR"];
 
-    if (!trainerName || !friendCode) {
-      return res.status(400).json({ message: "Missing fields" });
+    if (trainerName !== undefined) {
+      if (!trainerName) {
+        return res.status(400).json({ message: "Trainer name is required" });
+      }
+      updates.trainerName = trainerName;
+    }
+
+    if (friendCode !== undefined) {
+      if (!friendCode) {
+        return res.status(400).json({ message: "Friend code is required" });
+      }
+      updates.code = friendCode;
+    }
+
+    if (team !== undefined) {
+      const normalizedTeam = String(team).toUpperCase();
+
+      if (!validTeams.includes(normalizedTeam)) {
+        return res.status(400).json({ message: "Invalid team selection" });
+      }
+
+      updates.team = normalizedTeam;
+    }
+
+    if (!Object.keys(updates).length) {
+      return res.status(400).json({ message: "No fields provided" });
     }
 
     const updated = await prisma.entry.update({
       where: { id: Number(id) },
-      data: { trainerName, code: friendCode },
+      data: updates,
     });
     return res.json(updated);
   }

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -26,16 +26,42 @@ export default async function handler(req, res) {
       return res.status(403).json({ error: "Access denied" });
     }
 
-    const { trainerName, friendCode } = req.body;
+    const { trainerName, friendCode, team } = req.body;
+    const updates = {};
 
-    if (!trainerName || !friendCode) {
-      return res.status(400).json({ error: "Missing fields" });
+    if (trainerName !== undefined) {
+      if (!trainerName) {
+        return res.status(400).json({ error: "Trainer name is required" });
+      }
+      updates.trainerName = trainerName;
+    }
+
+    if (friendCode !== undefined) {
+      if (!friendCode) {
+        return res.status(400).json({ error: "Friend code is required" });
+      }
+      updates.code = friendCode;
+    }
+
+    if (team !== undefined) {
+      const normalizedTeam = String(team).toUpperCase();
+      const validTeams = ["INSTINCT", "MYSTIC", "VALOR"];
+
+      if (!validTeams.includes(normalizedTeam)) {
+        return res.status(400).json({ error: "Invalid team selection" });
+      }
+
+      updates.team = normalizedTeam;
+    }
+
+    if (!Object.keys(updates).length) {
+      return res.status(400).json({ error: "No fields provided for update" });
     }
 
     try {
       const updatedEntry = await prisma.entry.update({
         where: { id: entryId },
-        data: { trainerName, code: friendCode },
+        data: updates,
       });
       res.status(200).json(updatedEntry);
     } catch (err) {


### PR DESCRIPTION
## Summary
- allow users to edit each of their owned friend code entries directly from the account page
- permit admins to edit entry teams alongside trainer names and codes
- update test schema to reflect entry team column

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443390ac348324b30c4d538480a67a)