### PR TITLE
Revert account editing changes

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -9,7 +9,7 @@ export default function Admin({ users, entries, searchStrings }) {
 
   const [entryList, setEntryList] = useState(entries);
   const [editingEntryId, setEditingEntryId] = useState(null);
-  const [editForm, setEditForm] = useState({ trainerName: "", friendCode: "", team: "MYSTIC" });
+  const [editForm, setEditForm] = useState({ trainerName: "", friendCode: "" });
   const [passwordResets, setPasswordResets] = useState({});
 
   // Sidebar "accordion" state (matches your production look: green buttons on the left)
@@ -67,16 +67,12 @@ export default function Admin({ users, entries, searchStrings }) {
 
   const startEdit = (entry) => {
     setEditingEntryId(entry.id);
-    setEditForm({
-      trainerName: entry.trainerName,
-      friendCode: entry.code,
-      team: entry.team || "INSTINCT",
-    });
+    setEditForm({ trainerName: entry.trainerName, friendCode: entry.code });
   };
 
   const cancelEdit = () => {
     setEditingEntryId(null);
-    setEditForm({ trainerName: "", friendCode: "", team: "MYSTIC" });
+    setEditForm({ trainerName: "", friendCode: "" });
   };
 
   const handleEntrySave = async (id) => {
@@ -147,7 +143,6 @@ export default function Admin({ users, entries, searchStrings }) {
                     <th>ID</th>
                     <th>Trainer</th>
                     <th>Friend Code</th>
-                    <th>Team</th>
                     <th>Owner IGN</th>
                     <th>Actions</th>
                   </tr>
@@ -186,22 +181,6 @@ export default function Admin({ users, entries, searchStrings }) {
                           />
                         ) : (
                           entry.code
-                        )}
-                      </td>
-                      <td>
-                        {editingEntryId === entry.id ? (
-                          <select
-                            value={editForm.team}
-                            onChange={(e) =>
-                              setEditForm((prev) => ({ ...prev, team: e.target.value }))
-                            }
-                          >
-                            <option value="INSTINCT">Instinct (Yellow)</option>
-                            <option value="MYSTIC">Mystic (Blue)</option>
-                            <option value="VALOR">Valor (Red)</option>
-                          </select>
-                        ) : (
-                          entry.team
                         )}
                       </td>
                       <td>{entry.owner?.ign}</td>

--- a/pages/api/admin/entries/[id].js
+++ b/pages/api/admin/entries/[id].js
@@ -1,9 +1,8 @@
-import { getServerSession } from "next-auth";
+import { getSession } from "next-auth/react";
 import prisma from "../../../../lib/prisma";
-import { authOptions } from "../../auth/[...nextauth]";
 
 export default async function handler(req, res) {
-  const session = await getServerSession(req, res, authOptions);
+  const session = await getSession({ req });
   if (!session || session.user.role !== "admin") {
     return res.status(403).json({ message: "Access denied" });
   }
@@ -16,41 +15,15 @@ export default async function handler(req, res) {
   }
 
   if (req.method === "PUT") {
-    const { trainerName, friendCode, team } = req.body;
-    const updates = {};
-    const validTeams = ["INSTINCT", "MYSTIC", "VALOR"];
+    const { trainerName, friendCode } = req.body;
 
-    if (trainerName !== undefined) {
-      if (!trainerName) {
-        return res.status(400).json({ message: "Trainer name is required" });
-      }
-      updates.trainerName = trainerName;
-    }
-
-    if (friendCode !== undefined) {
-      if (!friendCode) {
-        return res.status(400).json({ message: "Friend code is required" });
-      }
-      updates.code = friendCode;
-    }
-
-    if (team !== undefined) {
-      const normalizedTeam = String(team).toUpperCase();
-
-      if (!validTeams.includes(normalizedTeam)) {
-        return res.status(400).json({ message: "Invalid team selection" });
-      }
-
-      updates.team = normalizedTeam;
-    }
-
-    if (!Object.keys(updates).length) {
-      return res.status(400).json({ message: "No fields provided" });
+    if (!trainerName || !friendCode) {
+      return res.status(400).json({ message: "Missing fields" });
     }
 
     const updated = await prisma.entry.update({
       where: { id: Number(id) },
-      data: updates,
+      data: { trainerName, code: friendCode },
     });
     return res.json(updated);
   }

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -1,16 +1,14 @@
-import { getServerSession } from "next-auth";
+import { getSession } from "next-auth/react";
 import prisma from "../../../lib/prisma";
-import { authOptions } from "../auth/[...nextauth]";
 
 export default async function handler(req, res) {
-  const session = await getServerSession(req, res, authOptions);
+  const session = await getSession({ req });
 
   if (!session) {
     return res.status(403).json({ error: "Access denied" });
   }
 
   const entryId = parseInt(req.query.id);
-  const userId = Number(session.user.id);
 
   const existingEntry = await prisma.entry.findUnique({
     where: { id: entryId },
@@ -20,7 +18,7 @@ export default async function handler(req, res) {
     return res.status(404).json({ error: "Entry not found" });
   }
 
-  const isOwner = !Number.isNaN(userId) && existingEntry.ownerId === userId;
+  const isOwner = existingEntry.ownerId === session.user.id;
   const isAdmin = session.user.role === "admin";
 
   if (req.method === "PATCH") {
@@ -28,42 +26,16 @@ export default async function handler(req, res) {
       return res.status(403).json({ error: "Access denied" });
     }
 
-    const { trainerName, friendCode, team } = req.body;
-    const updates = {};
+    const { trainerName, friendCode } = req.body;
 
-    if (trainerName !== undefined) {
-      if (!trainerName) {
-        return res.status(400).json({ error: "Trainer name is required" });
-      }
-      updates.trainerName = trainerName;
-    }
-
-    if (friendCode !== undefined) {
-      if (!friendCode) {
-        return res.status(400).json({ error: "Friend code is required" });
-      }
-      updates.code = friendCode;
-    }
-
-    if (team !== undefined) {
-      const normalizedTeam = String(team).toUpperCase();
-      const validTeams = ["INSTINCT", "MYSTIC", "VALOR"];
-
-      if (!validTeams.includes(normalizedTeam)) {
-        return res.status(400).json({ error: "Invalid team selection" });
-      }
-
-      updates.team = normalizedTeam;
-    }
-
-    if (!Object.keys(updates).length) {
-      return res.status(400).json({ error: "No fields provided for update" });
+    if (!trainerName || !friendCode) {
+      return res.status(400).json({ error: "Missing fields" });
     }
 
     try {
       const updatedEntry = await prisma.entry.update({
         where: { id: entryId },
-        data: updates,
+        data: { trainerName, code: friendCode },
       });
       res.status(200).json(updatedEntry);
     } catch (err) {


### PR DESCRIPTION
## Summary
- revert the account page back to the trainer profile form while keeping the team badge display
- remove admin table and API support for editing team values on entries
- simplify entry update APIs to only edit trainer name and friend code and restore session handling

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443ee7f5d08324b36820a1c6285f13)