### PR TITLE
Add private gym map and CSV management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules
 /data/local-events.json*
 /data/event-overrides.json*
 /data/event-type-rules.json*
+/data/gym-imports/*.csv
 /public/uploads/guides/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ node_modules
 /data/local-events.json*
 /data/event-overrides.json*
 /data/event-type-rules.json*
+/data/gyms.json*
 /data/gym-imports/*.csv
 /public/uploads/guides/*

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -98,6 +98,11 @@ export default function Navbar() {
               <Link href="/pokedex" className="nav-item nav-subitem">
                 Pokédex
               </Link>
+              {session && (
+                <Link href="/gyms" className="nav-item nav-subitem">
+                  Gym Map
+                </Link>
+              )}
             </div>
           </div>
 
@@ -135,6 +140,9 @@ export default function Navbar() {
                     </Link>
                     <Link href="/admin/guide-images" className="nav-item nav-subitem">
                       Guide Pictures
+                    </Link>
+                    <Link href="/admin/gyms" className="nav-item nav-subitem">
+                      Gym Data
                     </Link>
                   </div>
                 </div>

--- a/components/gyms/GymMap.tsx
+++ b/components/gyms/GymMap.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import {
   CircleMarker,
@@ -75,7 +75,7 @@ function MapController({
 }) {
   const map = useMap();
 
-  useMemo(() => {
+  useEffect(() => {
     if (selectedGym) {
       map.flyTo([selectedGym.lat, selectedGym.lon], 17, { duration: 0.7 });
       return;
@@ -253,7 +253,7 @@ export default function GymMap({ gyms, importedAt }: GymMapProps) {
             const selected = selectedId === gym.id;
 
             return (
-              <span key={gym.id}>
+              <Fragment key={gym.id}>
                 {opacity > 0 && (
                   <CircleMarker
                     center={[gym.lat, gym.lon]}
@@ -296,7 +296,7 @@ export default function GymMap({ gyms, importedAt }: GymMapProps) {
                     </div>
                   </Popup>
                 </CircleMarker>
-              </span>
+              </Fragment>
             );
           })}
         </MapContainer>

--- a/components/gyms/GymMap.tsx
+++ b/components/gyms/GymMap.tsx
@@ -1,0 +1,306 @@
+import { useMemo, useState } from "react";
+import { useRouter } from "next/router";
+import {
+  CircleMarker,
+  MapContainer,
+  Popup,
+  TileLayer,
+  useMap,
+} from "react-leaflet";
+import type { LatLngBoundsExpression } from "leaflet";
+
+export interface MapGym {
+  id: string;
+  name: string;
+  alias: string | null;
+  url: string | null;
+  lat: number;
+  lon: number;
+  exRaidEligible: boolean;
+  firstSeenAt: string | null;
+}
+
+interface GymMapProps {
+  gyms: MapGym[];
+  importedAt: string | null;
+}
+
+interface UserLocation {
+  lat: number;
+  lon: number;
+}
+
+const NEW_GYM_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function displayName(gym: MapGym): string {
+  return gym.alias || gym.name;
+}
+
+function newGymOpacity(gym: MapGym): number {
+  if (!gym.firstSeenAt) {
+    return 0;
+  }
+
+  const age = Date.now() - Date.parse(gym.firstSeenAt);
+
+  if (!Number.isFinite(age) || age < 0 || age >= NEW_GYM_WINDOW_MS) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, 1 - age / NEW_GYM_WINDOW_MS));
+}
+
+function distanceKm(from: UserLocation, gym: MapGym): number {
+  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+  const earthRadiusKm = 6371;
+  const latDifference = toRadians(gym.lat - from.lat);
+  const lonDifference = toRadians(gym.lon - from.lon);
+  const fromLat = toRadians(from.lat);
+  const gymLat = toRadians(gym.lat);
+  const a =
+    Math.sin(latDifference / 2) ** 2 +
+    Math.cos(fromLat) * Math.cos(gymLat) * Math.sin(lonDifference / 2) ** 2;
+
+  return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function MapController({
+  gyms,
+  selectedGym,
+  userLocation,
+}: {
+  gyms: MapGym[];
+  selectedGym: MapGym | null;
+  userLocation: UserLocation | null;
+}) {
+  const map = useMap();
+
+  useMemo(() => {
+    if (selectedGym) {
+      map.flyTo([selectedGym.lat, selectedGym.lon], 17, { duration: 0.7 });
+      return;
+    }
+
+    if (userLocation) {
+      map.flyTo([userLocation.lat, userLocation.lon], 14, { duration: 0.7 });
+      return;
+    }
+
+    if (gyms.length > 0) {
+      const bounds = gyms.map((gym) => [gym.lat, gym.lon]) as LatLngBoundsExpression;
+      map.fitBounds(bounds, { padding: [28, 28], maxZoom: 15 });
+    }
+  }, [gyms, map, selectedGym, userLocation]);
+
+  return null;
+}
+
+export default function GymMap({ gyms, importedAt }: GymMapProps) {
+  const router = useRouter();
+  const [search, setSearch] = useState("");
+  const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [locating, setLocating] = useState(false);
+  const selectedId = typeof router.query.gym === "string" ? router.query.gym : null;
+  const selectedGym = gyms.find((gym) => gym.id === selectedId) || null;
+
+  const filteredGyms = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    const matching = term
+      ? gyms.filter((gym) =>
+          [gym.name, gym.alias || ""].some((value) => value.toLowerCase().includes(term)),
+        )
+      : gyms;
+
+    return [...matching].sort((left, right) => {
+      if (userLocation) {
+        return distanceKm(userLocation, left) - distanceKm(userLocation, right);
+      }
+
+      return displayName(left).localeCompare(displayName(right), "en-GB");
+    });
+  }, [gyms, search, userLocation]);
+
+  function selectGym(gym: MapGym) {
+    void router.replace(
+      { pathname: "/gyms", query: { gym: gym.id } },
+      undefined,
+      { shallow: true, scroll: false },
+    );
+  }
+
+  function locateUser() {
+    setLocationError(null);
+
+    if (!navigator.geolocation) {
+      setLocationError("Location is not supported by this browser.");
+      return;
+    }
+
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setUserLocation({
+          lat: position.coords.latitude,
+          lon: position.coords.longitude,
+        });
+        setLocating(false);
+      },
+      (error) => {
+        setLocationError(
+          error.code === error.PERMISSION_DENIED
+            ? "Location permission was not granted."
+            : "Your location could not be determined.",
+        );
+        setLocating(false);
+      },
+      { enableHighAccuracy: true, timeout: 10_000, maximumAge: 60_000 },
+    );
+  }
+
+  if (gyms.length === 0) {
+    return (
+      <section className="gym-empty">
+        <h2>No gym data has been uploaded</h2>
+        <p>An administrator needs to upload the current gym CSV before the map is available.</p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="gym-map-layout">
+      <aside className="gym-map-sidebar">
+        <div className="gym-map-controls">
+          <label>
+            Search gyms
+            <input
+              type="search"
+              value={search}
+              placeholder="Official name or community alias"
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </label>
+          <div className="location-actions">
+            <button type="button" onClick={locateUser} disabled={locating}>
+              {locating ? "Finding…" : userLocation ? "Update my location" : "Gyms near me"}
+            </button>
+            {userLocation && (
+              <button type="button" className="secondary" onClick={() => setUserLocation(null)}>
+                Clear location
+              </button>
+            )}
+          </div>
+          {locationError && <p className="gym-error">{locationError}</p>}
+          <p className="gym-count">
+            {filteredGyms.length} of {gyms.length} gyms
+            {importedAt && (
+              <small>Updated {new Date(importedAt).toLocaleString("en-GB")}</small>
+            )}
+          </p>
+        </div>
+
+        <div className="gym-results" aria-label="Gym results">
+          {filteredGyms.slice(0, 100).map((gym) => {
+            const opacity = newGymOpacity(gym);
+            return (
+              <button
+                key={gym.id}
+                type="button"
+                className={selectedId === gym.id ? "selected" : ""}
+                onClick={() => selectGym(gym)}
+              >
+                <span>
+                  <strong>{displayName(gym)}</strong>
+                  {gym.alias && <small>{gym.name}</small>}
+                </span>
+                <span className="gym-result-meta">
+                  {opacity > 0 && <em>New</em>}
+                  {userLocation && <small>{distanceKm(userLocation, gym).toFixed(1)} km</small>}
+                </span>
+              </button>
+            );
+          })}
+          {filteredGyms.length > 100 && (
+            <p className="result-limit">Refine the search to see results beyond the first 100.</p>
+          )}
+        </div>
+      </aside>
+
+      <div className="gym-map-panel">
+        <MapContainer center={[53.49, -2.52]} zoom={12} scrollWheelZoom className="gym-leaflet-map">
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <MapController
+            gyms={filteredGyms}
+            selectedGym={selectedGym}
+            userLocation={userLocation}
+          />
+
+          {userLocation && (
+            <CircleMarker
+              center={[userLocation.lat, userLocation.lon]}
+              radius={8}
+              pathOptions={{ color: "#58a6ff", fillColor: "#58a6ff", fillOpacity: 0.75, weight: 3 }}
+            >
+              <Popup>Your current location</Popup>
+            </CircleMarker>
+          )}
+
+          {filteredGyms.map((gym) => {
+            const opacity = newGymOpacity(gym);
+            const selected = selectedId === gym.id;
+
+            return (
+              <span key={gym.id}>
+                {opacity > 0 && (
+                  <CircleMarker
+                    center={[gym.lat, gym.lon]}
+                    radius={18 + opacity * 7}
+                    interactive={false}
+                    pathOptions={{
+                      className: "new-gym-aura",
+                      color: "#f2cc60",
+                      fillColor: "#f2cc60",
+                      opacity: 0.2 + opacity * 0.65,
+                      fillOpacity: 0.05 + opacity * 0.2,
+                      weight: 3,
+                    }}
+                  />
+                )}
+                <CircleMarker
+                  center={[gym.lat, gym.lon]}
+                  radius={selected ? 10 : 7}
+                  eventHandlers={{ click: () => selectGym(gym) }}
+                  pathOptions={{
+                    color: selected ? "#ffffff" : gym.exRaidEligible ? "#a371f7" : "#2ea043",
+                    fillColor: gym.exRaidEligible ? "#8957e5" : "#238636",
+                    fillOpacity: 0.92,
+                    weight: selected ? 4 : 2,
+                  }}
+                >
+                  <Popup>
+                    <div className="gym-popup">
+                      <strong>{displayName(gym)}</strong>
+                      {gym.alias && <small>Official name: {gym.name}</small>}
+                      {opacity > 0 && <span className="new-badge">New gym</span>}
+                      {gym.exRaidEligible && <span>EX raid eligible</span>}
+                      <a
+                        href={`https://www.google.com/maps/dir/?api=1&destination=${gym.lat},${gym.lon}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Directions in Google Maps
+                      </a>
+                    </div>
+                  </Popup>
+                </CircleMarker>
+              </span>
+            );
+          })}
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/gyms/NewGymTicker.tsx
+++ b/components/gyms/NewGymTicker.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+
+interface NewGymItem {
+  id: string;
+  name: string;
+  alias: string | null;
+  displayName: string;
+  firstSeenAt: string | null;
+}
+
+interface NewGymPayload {
+  gyms?: NewGymItem[];
+}
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+export default function NewGymTicker() {
+  const { status } = useSession();
+  const [gyms, setGyms] = useState<NewGymItem[]>([]);
+
+  useEffect(() => {
+    if (status !== "authenticated") {
+      setGyms([]);
+      return;
+    }
+
+    let controller: AbortController | null = null;
+
+    async function loadGyms() {
+      controller?.abort();
+      controller = new AbortController();
+
+      try {
+        const response = await fetch("/api/gyms/new", {
+          signal: controller.signal,
+          cache: "no-store",
+          headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+          setGyms([]);
+          return;
+        }
+
+        const payload = (await response.json()) as NewGymPayload;
+        setGyms(Array.isArray(payload.gyms) ? payload.gyms : []);
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          setGyms([]);
+        }
+      }
+    }
+
+    const refresh = () => void loadGyms();
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        refresh();
+      }
+    };
+
+    refresh();
+    const timer = window.setInterval(refresh, REFRESH_INTERVAL_MS);
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      controller?.abort();
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [status]);
+
+  if (status !== "authenticated" || gyms.length === 0) {
+    return null;
+  }
+
+  const items = gyms.map((gym) => (
+    <Link key={gym.id} href={`/gyms?gym=${encodeURIComponent(gym.id)}`} className="new-gym-item">
+      <strong>{gym.displayName}</strong>
+      {gym.alias && <span className="official-name">({gym.name})</span>}
+    </Link>
+  ));
+
+  return (
+    <aside className="new-gym-ticker" aria-label="Newly added gyms">
+      <Link href="/gyms" className="new-gym-label">
+        <span aria-hidden="true">✨</span>
+        <strong>New gyms</strong>
+      </Link>
+      <div className="new-gym-viewport">
+        <div className="new-gym-track">
+          <div className="new-gym-copy">{items}</div>
+          <div className="new-gym-copy" aria-hidden="true">{items}</div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/lib/gyms.ts
+++ b/lib/gyms.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const NEW_GYM_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+const GYM_DATA_FILE =
+  process.env.GYM_DATA_FILE?.trim() || path.join(process.cwd(), "data", "gyms.json");
+
+export interface GymRecord {
+  id: string;
+  name: string;
+  alias: string | null;
+  url: string | null;
+  lat: number;
+  lon: number;
+  exRaidEligible: boolean;
+  firstSeenAt: string | null;
+}
+
+export interface GymState {
+  version: 1;
+  importedAt: string | null;
+  sourceFile: string | null;
+  gyms: GymRecord[];
+}
+
+export interface GymImportSummary {
+  total: number;
+  added: number;
+  updated: number;
+  removed: number;
+  unchanged: number;
+  importedAt: string;
+  sourceFile: string;
+}
+
+const EMPTY_STATE: GymState = {
+  version: 1,
+  importedAt: null,
+  sourceFile: null,
+  gyms: [],
+};
+
+function validGym(value: unknown): value is GymRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const gym = value as Partial<GymRecord>;
+
+  return (
+    typeof gym.id === "string" &&
+    gym.id.length > 0 &&
+    typeof gym.name === "string" &&
+    gym.name.length > 0 &&
+    typeof gym.lat === "number" &&
+    Number.isFinite(gym.lat) &&
+    gym.lat >= -90 &&
+    gym.lat <= 90 &&
+    typeof gym.lon === "number" &&
+    Number.isFinite(gym.lon) &&
+    gym.lon >= -180 &&
+    gym.lon <= 180
+  );
+}
+
+export async function readGymState(): Promise<GymState> {
+  try {
+    const source = await fs.readFile(GYM_DATA_FILE, "utf8");
+    const parsed = JSON.parse(source) as Partial<GymState>;
+
+    if (!Array.isArray(parsed.gyms)) {
+      return { ...EMPTY_STATE };
+    }
+
+    return {
+      version: 1,
+      importedAt:
+        typeof parsed.importedAt === "string" ? parsed.importedAt : null,
+      sourceFile: typeof parsed.sourceFile === "string" ? parsed.sourceFile : null,
+      gyms: parsed.gyms.filter(validGym).map((gym) => ({
+        ...gym,
+        alias:
+          typeof gym.alias === "string" && gym.alias.trim()
+            ? gym.alias.trim()
+            : null,
+        url: typeof gym.url === "string" && gym.url.trim() ? gym.url.trim() : null,
+        exRaidEligible: gym.exRaidEligible === true,
+        firstSeenAt:
+          typeof gym.firstSeenAt === "string" && gym.firstSeenAt.trim()
+            ? gym.firstSeenAt
+            : null,
+      })),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ...EMPTY_STATE };
+    }
+
+    console.error("Unable to read gym data", error);
+    return { ...EMPTY_STATE };
+  }
+}
+
+export async function writeGymState(state: GymState): Promise<void> {
+  const directory = path.dirname(GYM_DATA_FILE);
+  const temporaryFile = `${GYM_DATA_FILE}.tmp-${process.pid}-${Date.now()}`;
+
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(temporaryFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await fs.rename(temporaryFile, GYM_DATA_FILE);
+}
+
+export function getGymDisplayName(gym: Pick<GymRecord, "name" | "alias">): string {
+  return gym.alias || gym.name;
+}
+
+export function gymIsNew(gym: GymRecord, now = Date.now()): boolean {
+  if (!gym.firstSeenAt) {
+    return false;
+  }
+
+  const firstSeen = Date.parse(gym.firstSeenAt);
+  return Number.isFinite(firstSeen) && now - firstSeen >= 0 && now - firstSeen < NEW_GYM_WINDOW_MS;
+}
+
+export function getNewGymOpacity(gym: GymRecord, now = Date.now()): number {
+  if (!gymIsNew(gym, now) || !gym.firstSeenAt) {
+    return 0;
+  }
+
+  const age = now - Date.parse(gym.firstSeenAt);
+  return Math.max(0, Math.min(1, 1 - age / NEW_GYM_WINDOW_MS));
+}
+
+export function sortGyms(gyms: GymRecord[]): GymRecord[] {
+  return [...gyms].sort((left, right) =>
+    getGymDisplayName(left).localeCompare(getGymDisplayName(right), "en-GB"),
+  );
+}
+
+export function cleanAlias(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const alias = value.trim().replace(/\s+/g, " ");
+
+  if (!alias) {
+    return null;
+  }
+
+  if (alias.length > 100) {
+    throw new Error("Gym aliases must be 100 characters or fewer.");
+  }
+
+  return alias;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,18 @@
       "dependencies": {
         "@prisma/client": "^5.8.0",
         "bcryptjs": "^3.0.3",
+        "csv-parse": "^5.6.0",
         "gray-matter": "^4.0.3",
+        "leaflet": "^1.9.4",
         "next": "^15.5.7",
         "next-auth": "^4.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.1",
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.16",
         "@types/node": "^20.17.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -1896,6 +1900,17 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2026,6 +2041,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2078,6 +2100,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -3630,6 +3662,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6745,6 +6783,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8546,6 +8590,20 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,18 @@
   "dependencies": {
     "@prisma/client": "^5.8.0",
     "bcryptjs": "^3.0.3",
+    "csv-parse": "^5.6.0",
     "gray-matter": "^4.0.3",
+    "leaflet": "^1.9.4",
     "next": "^15.5.7",
     "next-auth": "^4.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.16",
     "@types/node": "^20.17.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,14 @@
 import { SessionProvider } from "next-auth/react"
 import { useRouter } from "next/router"
+import "leaflet/dist/leaflet.css"
 import "../styles/globals.css"
 import "../styles/navbar.css"
 import "../styles/tickers.css"
+import "../styles/gyms.css"
 import Navbar from "../components/Navbar"
 import EventTicker from "../components/events/EventTicker"
 import RaidBossTicker from "../components/events/RaidBossTicker"
+import NewGymTicker from "../components/gyms/NewGymTicker"
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }) {
   const router = useRouter()
@@ -16,6 +19,7 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
       <Navbar />
       {showEventTicker && <EventTicker />}
       <RaidBossTicker />
+      <NewGymTicker />
       <Component {...pageProps} />
     </SessionProvider>
   )

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getServerSession } from "next-auth/next";
 import { useSession } from "next-auth/react";
 import { useMemo, useState } from "react";
@@ -130,6 +131,10 @@ export default function Admin({ users, entries, searchStrings }) {
           <NavButton id="entries">Entries ({counts.entries})</NavButton>
           <NavButton id="users">Users ({counts.users})</NavButton>
           <NavButton id="searches">Saved search strings ({counts.searches})</NavButton>
+          <Link href="/admin/gyms" className="admin-navbtn admin-navlink">
+            <span>Gym data</span>
+            <span className="admin-navbtn-caret">→</span>
+          </Link>
         </aside>
 
         {/* RIGHT: content */}
@@ -328,6 +333,10 @@ export default function Admin({ users, entries, searchStrings }) {
           background: #1f8a3b;
           cursor: pointer;
           box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+        }
+        .admin-navlink {
+          box-sizing: border-box;
+          text-decoration: none;
         }
         .admin-navbtn:hover {
           filter: brightness(1.05);

--- a/pages/admin/gyms.tsx
+++ b/pages/admin/gyms.tsx
@@ -1,0 +1,296 @@
+import Link from "next/link";
+import Head from "next/head";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import { useMemo, useState, type ChangeEvent } from "react";
+import { readGymState, sortGyms, type GymRecord } from "../../lib/gyms";
+import { authOptions } from "../api/auth/[...nextauth]";
+
+const MAX_CSV_SIZE = 5 * 1024 * 1024;
+
+interface GymAdminProps {
+  initialGyms: GymRecord[];
+  importedAt: string | null;
+  sourceFile: string | null;
+}
+
+interface ImportResponse {
+  error?: string;
+  message?: string;
+  summary?: {
+    total: number;
+    added: number;
+    updated: number;
+    removed: number;
+    unchanged: number;
+    sourceFile: string;
+  };
+}
+
+function fileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () =>
+      typeof reader.result === "string"
+        ? resolve(reader.result)
+        : reject(new Error("The CSV could not be read."));
+    reader.onerror = () => reject(new Error("The CSV could not be read."));
+    reader.readAsDataURL(file);
+  });
+}
+
+export const getServerSideProps: GetServerSideProps<GymAdminProps> = async (
+  context,
+) => {
+  const session = await getServerSession(
+    context.req,
+    context.res,
+    authOptions as NextAuthOptions,
+  );
+
+  if ((session?.user as { role?: string } | undefined)?.role !== "admin") {
+    return {
+      redirect: { destination: "/login", permanent: false },
+    };
+  }
+
+  const state = await readGymState();
+
+  return {
+    props: {
+      initialGyms: sortGyms(state.gyms),
+      importedAt: state.importedAt,
+      sourceFile: state.sourceFile,
+    },
+  };
+};
+
+export default function GymAdminPage({
+  initialGyms,
+  importedAt,
+  sourceFile,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [gyms, setGyms] = useState(initialGyms);
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [search, setSearch] = useState("");
+  const [aliasDrafts, setAliasDrafts] = useState<Record<string, string>>({});
+  const [savingAlias, setSavingAlias] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const filteredGyms = useMemo(() => {
+    const term = search.trim().toLowerCase();
+
+    if (!term) {
+      return gyms;
+    }
+
+    return gyms.filter((gym) =>
+      [gym.name, gym.alias || "", gym.id].some((value) =>
+        value.toLowerCase().includes(term),
+      ),
+    );
+  }, [gyms, search]);
+
+  function chooseFile(event: ChangeEvent<HTMLInputElement>) {
+    setFile(event.target.files?.[0] ?? null);
+    setMessage(null);
+    setError(null);
+  }
+
+  async function uploadCsv() {
+    setMessage(null);
+    setError(null);
+
+    if (!file) {
+      setError("Choose a gym CSV first.");
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith(".csv")) {
+      setError("The selected file must be a CSV.");
+      return;
+    }
+
+    if (file.size === 0 || file.size > MAX_CSV_SIZE) {
+      setError("Gym CSV files must be between 1 byte and 5 MB.");
+      return;
+    }
+
+    setUploading(true);
+
+    try {
+      const dataUrl = await fileAsDataUrl(file);
+      const response = await fetch("/api/admin/gyms/upload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fileName: file.name, dataUrl }),
+      });
+      const payload = (await response.json()) as ImportResponse;
+
+      if (!response.ok || !payload.summary) {
+        throw new Error(payload.error || "The gym CSV could not be imported.");
+      }
+
+      const summary = payload.summary;
+      setMessage(
+        `${payload.message} ${summary.total} gyms loaded; ${summary.added} added, ` +
+          `${summary.updated} updated and ${summary.removed} removed. Archived as ${summary.sourceFile}.`,
+      );
+      setFile(null);
+
+      window.setTimeout(() => window.location.reload(), 1200);
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "The gym CSV could not be imported.",
+      );
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function saveAlias(gym: GymRecord) {
+    setMessage(null);
+    setError(null);
+    setSavingAlias(gym.id);
+
+    try {
+      const alias = aliasDrafts[gym.id] ?? gym.alias ?? "";
+      const response = await fetch("/api/admin/gyms/alias", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: gym.id, alias }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok || !payload.gym) {
+        throw new Error(payload.error || "The gym alias could not be saved.");
+      }
+
+      setGyms((current) =>
+        current.map((item) => (item.id === gym.id ? payload.gym : item)),
+      );
+      setAliasDrafts((current) => {
+        const next = { ...current };
+        delete next[gym.id];
+        return next;
+      });
+      setMessage(payload.message);
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "The gym alias could not be saved.",
+      );
+    } finally {
+      setSavingAlias(null);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Gym Data | Leigh Pokémon Go Admin</title>
+      </Head>
+      <main className="container gym-admin-page">
+        <header className="gym-admin-header">
+          <div>
+            <p className="eyebrow">Admin tools</p>
+            <h1>Gym data</h1>
+            <p>Import the current gym export and manage community aliases.</p>
+          </div>
+          <div className="header-links">
+            <Link href="/gyms">Open gym map</Link>
+            <Link href="/admin">Back to admin</Link>
+          </div>
+        </header>
+
+        {message && <p className="gym-notice success">{message}</p>}
+        {error && <p className="gym-notice error">{error}</p>}
+
+        <section className="gym-admin-card uploader-card">
+          <div>
+            <h2>Upload gym CSV</h2>
+            <p>
+              Accepted uploads are archived under <code>data/gym-imports</code> using UK
+              local time in the format <code>YYYY-MM-DD HH-mm-ss - gyms.csv</code>.
+            </p>
+            <p className="muted">
+              The first upload is treated as the baseline. Later uploads preserve aliases
+              and mark previously unseen gym IDs as new for seven days.
+            </p>
+          </div>
+          <div className="upload-controls">
+            <input type="file" accept=".csv,text/csv" onChange={chooseFile} />
+            <button type="button" onClick={uploadCsv} disabled={uploading}>
+              {uploading ? "Importing…" : "Upload and import"}
+            </button>
+          </div>
+          <dl className="import-status">
+            <div><dt>Current gyms</dt><dd>{gyms.length}</dd></div>
+            <div><dt>Last upload</dt><dd>{importedAt ? new Date(importedAt).toLocaleString("en-GB") : "None"}</dd></div>
+            <div><dt>Archive file</dt><dd>{sourceFile || "None"}</dd></div>
+          </dl>
+        </section>
+
+        <section className="gym-admin-card alias-card">
+          <div className="alias-heading">
+            <div>
+              <h2>Community aliases</h2>
+              <p className="muted">Aliases are shown prominently while the official name remains visible.</p>
+            </div>
+            <label>
+              Search gyms
+              <input
+                type="search"
+                value={search}
+                placeholder="Name, alias or gym ID"
+                onChange={(event) => setSearch(event.target.value)}
+              />
+            </label>
+          </div>
+
+          {gyms.length === 0 ? (
+            <p>No gyms are available until the first CSV is uploaded.</p>
+          ) : (
+            <div className="alias-list">
+              {filteredGyms.slice(0, 100).map((gym) => (
+                <article key={gym.id}>
+                  <div className="gym-identity">
+                    <strong>{gym.alias || gym.name}</strong>
+                    {gym.alias && <small>Official: {gym.name}</small>}
+                    <small>{gym.id}</small>
+                  </div>
+                  <label>
+                    Community alias
+                    <input
+                      value={aliasDrafts[gym.id] ?? gym.alias ?? ""}
+                      maxLength={100}
+                      placeholder="Leave blank to use the official name"
+                      onChange={(event) =>
+                        setAliasDrafts((current) => ({
+                          ...current,
+                          [gym.id]: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    disabled={savingAlias === gym.id}
+                    onClick={() => saveAlias(gym)}
+                  >
+                    {savingAlias === gym.id ? "Saving…" : "Save alias"}
+                  </button>
+                </article>
+              ))}
+              {filteredGyms.length > 100 && (
+                <p className="muted">Refine the search to edit gyms beyond the first 100 results.</p>
+              )}
+            </div>
+          )}
+        </section>
+      </main>
+    </>
+  );
+}

--- a/pages/api/admin/gyms/alias.ts
+++ b/pages/api/admin/gyms/alias.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import {
+  cleanAlias,
+  readGymState,
+  writeGymState,
+  type GymRecord,
+} from "../../../../lib/gyms";
+import { authOptions } from "../../auth/[...nextauth]";
+
+interface AliasBody {
+  id?: unknown;
+  alias?: unknown;
+}
+
+type AliasResponse =
+  | { message: string; gym: GymRecord }
+  | { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<AliasResponse>,
+) {
+  if (req.method !== "PATCH") {
+    res.setHeader("Allow", "PATCH");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+
+  if ((session?.user as { role?: string } | undefined)?.role !== "admin") {
+    return res.status(403).json({ error: "Access denied" });
+  }
+
+  try {
+    const body = req.body as AliasBody;
+    const id = typeof body.id === "string" ? body.id.trim() : "";
+
+    if (!id) {
+      throw new Error("Gym ID is required.");
+    }
+
+    const alias = cleanAlias(body.alias);
+    const state = await readGymState();
+    const index = state.gyms.findIndex((gym) => gym.id === id);
+
+    if (index < 0) {
+      return res.status(404).json({ error: "Gym not found" });
+    }
+
+    const gym = { ...state.gyms[index], alias };
+    const gyms = [...state.gyms];
+    gyms[index] = gym;
+
+    await writeGymState({ ...state, gyms });
+
+    return res.status(200).json({
+      message: alias ? "Gym alias saved." : "Gym alias removed.",
+      gym,
+    });
+  } catch (error) {
+    console.error("Gym alias update failed", error);
+    return res.status(400).json({
+      error: error instanceof Error ? error.message : "The gym alias could not be saved.",
+    });
+  }
+}

--- a/pages/api/admin/gyms/upload.ts
+++ b/pages/api/admin/gyms/upload.ts
@@ -1,0 +1,313 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import { parse } from "csv-parse/sync";
+import {
+  readGymState,
+  writeGymState,
+  type GymImportSummary,
+  type GymRecord,
+} from "../../../../lib/gyms";
+import { authOptions } from "../../auth/[...nextauth]";
+
+const MAX_CSV_SIZE = 5 * 1024 * 1024;
+const IMPORT_DIRECTORY =
+  process.env.GYM_IMPORTS_DIRECTORY?.trim() ||
+  path.join(process.cwd(), "data", "gym-imports");
+
+interface UploadBody {
+  fileName?: unknown;
+  dataUrl?: unknown;
+}
+
+interface CsvGymRow {
+  id?: unknown;
+  name?: unknown;
+  url?: unknown;
+  lat?: unknown;
+  lon?: unknown;
+  __typename?: unknown;
+  ex_raid_eligible?: unknown;
+}
+
+type UploadResponse =
+  | { message: string; summary: GymImportSummary }
+  | { error: string };
+
+function requiredText(value: unknown, field: string, row: number): string {
+  const text = typeof value === "string" ? value.trim() : String(value ?? "").trim();
+
+  if (!text) {
+    throw new Error(`Row ${row}: ${field} is required.`);
+  }
+
+  return text;
+}
+
+function coordinate(value: unknown, field: "lat" | "lon", row: number): number {
+  const number = Number(value);
+  const minimum = field === "lat" ? -90 : -180;
+  const maximum = field === "lat" ? 90 : 180;
+
+  if (!Number.isFinite(number) || number < minimum || number > maximum) {
+    throw new Error(`Row ${row}: ${field} is not a valid coordinate.`);
+  }
+
+  return number;
+}
+
+function booleanValue(value: unknown): boolean {
+  if (value === true || value === 1) {
+    return true;
+  }
+
+  return ["true", "1", "yes"].includes(String(value ?? "").trim().toLowerCase());
+}
+
+function optionalUrl(value: unknown): string | null {
+  const url = typeof value === "string" ? value.trim() : "";
+
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return ["http:", "https:"].includes(parsed.protocol) ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeCsv(body: UploadBody): Buffer {
+  if (typeof body.fileName !== "string" || !body.fileName.toLowerCase().endsWith(".csv")) {
+    throw new Error("Choose a CSV file.");
+  }
+
+  if (typeof body.dataUrl !== "string") {
+    throw new Error("CSV data is required.");
+  }
+
+  const match = body.dataUrl.match(/^data:[^;]*;base64,([A-Za-z0-9+/=]+)$/);
+
+  if (!match) {
+    throw new Error("The uploaded CSV data is invalid.");
+  }
+
+  const buffer = Buffer.from(match[1], "base64");
+
+  if (buffer.length === 0 || buffer.length > MAX_CSV_SIZE) {
+    throw new Error("Gym CSV files must be between 1 byte and 5 MB.");
+  }
+
+  return buffer;
+}
+
+function parseGyms(buffer: Buffer): Omit<GymRecord, "alias" | "firstSeenAt">[] {
+  let rows: CsvGymRow[];
+
+  try {
+    rows = parse(buffer, {
+      bom: true,
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+      relax_column_count: true,
+    }) as CsvGymRow[];
+  } catch (error) {
+    throw new Error(
+      error instanceof Error ? `The CSV could not be parsed: ${error.message}` : "The CSV could not be parsed.",
+    );
+  }
+
+  if (rows.length === 0) {
+    throw new Error("The CSV does not contain any gym rows.");
+  }
+
+  if (rows.length > 10_000) {
+    throw new Error("The CSV contains more than 10,000 rows.");
+  }
+
+  const gyms = rows
+    .filter((row) => {
+      const type = String(row.__typename ?? "Gym").trim().toLowerCase();
+      return !type || type === "gym";
+    })
+    .map((row, index) => ({
+      id: requiredText(row.id, "id", index + 2),
+      name: requiredText(row.name, "name", index + 2),
+      url: optionalUrl(row.url),
+      lat: coordinate(row.lat, "lat", index + 2),
+      lon: coordinate(row.lon, "lon", index + 2),
+      exRaidEligible: booleanValue(row.ex_raid_eligible),
+    }));
+
+  if (gyms.length === 0) {
+    throw new Error("The CSV does not contain any Gym records.");
+  }
+
+  const ids = new Set<string>();
+
+  for (const gym of gyms) {
+    if (ids.has(gym.id)) {
+      throw new Error(`The CSV contains a duplicate gym ID: ${gym.id}`);
+    }
+    ids.add(gym.id);
+  }
+
+  return gyms;
+}
+
+function ukTimestampParts(date: Date): Record<string, string> {
+  return Object.fromEntries(
+    new Intl.DateTimeFormat("en-GB", {
+      timeZone: "Europe/London",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    })
+      .formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+}
+
+function uploadFileName(date: Date): string {
+  const parts = ukTimestampParts(date);
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}-${parts.minute}-${parts.second} - gyms.csv`;
+}
+
+async function archiveCsv(buffer: Buffer, uploadedAt: Date): Promise<string> {
+  await fs.mkdir(IMPORT_DIRECTORY, { recursive: true });
+
+  const baseName = uploadFileName(uploadedAt);
+  let fileName = baseName;
+  let suffix = 2;
+
+  while (true) {
+    const destination = path.join(IMPORT_DIRECTORY, fileName);
+
+    try {
+      await fs.writeFile(destination, buffer, { flag: "wx" });
+      return fileName;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+
+      fileName = baseName.replace(/ - gyms\.csv$/, `-${suffix} - gyms.csv`);
+      suffix += 1;
+    }
+  }
+}
+
+function sourceFieldsMatch(left: GymRecord, right: Omit<GymRecord, "alias" | "firstSeenAt">): boolean {
+  return (
+    left.name === right.name &&
+    left.url === right.url &&
+    left.lat === right.lat &&
+    left.lon === right.lon &&
+    left.exRaidEligible === right.exRaidEligible
+  );
+}
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "8mb",
+    },
+  },
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<UploadResponse>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+
+  if ((session?.user as { role?: string } | undefined)?.role !== "admin") {
+    return res.status(403).json({ error: "Access denied" });
+  }
+
+  try {
+    const buffer = decodeCsv(req.body as UploadBody);
+    const importedGyms = parseGyms(buffer);
+    const previous = await readGymState();
+    const previousById = new Map(previous.gyms.map((gym) => [gym.id, gym]));
+    const importedAtDate = new Date();
+    const importedAt = importedAtDate.toISOString();
+    const initialImport = previous.gyms.length === 0;
+    let added = 0;
+    let updated = 0;
+    let unchanged = 0;
+
+    const gyms: GymRecord[] = importedGyms.map((gym) => {
+      const existing = previousById.get(gym.id);
+
+      if (!existing) {
+        added += initialImport ? 0 : 1;
+        return {
+          ...gym,
+          alias: null,
+          firstSeenAt: initialImport ? null : importedAt,
+        };
+      }
+
+      if (sourceFieldsMatch(existing, gym)) {
+        unchanged += 1;
+      } else {
+        updated += 1;
+      }
+
+      return {
+        ...gym,
+        alias: existing.alias,
+        firstSeenAt: existing.firstSeenAt,
+      };
+    });
+
+    const importedIds = new Set(gyms.map((gym) => gym.id));
+    const removed = previous.gyms.filter((gym) => !importedIds.has(gym.id)).length;
+    const sourceFile = await archiveCsv(buffer, importedAtDate);
+
+    await writeGymState({
+      version: 1,
+      importedAt,
+      sourceFile,
+      gyms,
+    });
+
+    const summary: GymImportSummary = {
+      total: gyms.length,
+      added,
+      updated,
+      removed,
+      unchanged,
+      importedAt,
+      sourceFile,
+    };
+
+    return res.status(201).json({
+      message: initialImport
+        ? "Gym baseline imported successfully. Future uploads will identify newly added gyms."
+        : "Gym CSV imported successfully.",
+      summary,
+    });
+  } catch (error) {
+    console.error("Gym CSV import failed", error);
+    return res.status(400).json({
+      error: error instanceof Error ? error.message : "The gym CSV could not be imported.",
+    });
+  }
+}

--- a/pages/api/gyms/index.ts
+++ b/pages/api/gyms/index.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import { readGymState, sortGyms, type GymRecord } from "../../../lib/gyms";
+import { authOptions } from "../auth/[...nextauth]";
+
+type GymResponse =
+  | {
+      gyms: GymRecord[];
+      importedAt: string | null;
+      sourceFile: string | null;
+    }
+  | { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GymResponse>,
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+
+  const state = await readGymState();
+
+  res.setHeader("Cache-Control", "private, no-store");
+  return res.status(200).json({
+    gyms: sortGyms(state.gyms),
+    importedAt: state.importedAt,
+    sourceFile: state.sourceFile,
+  });
+}

--- a/pages/api/gyms/new.ts
+++ b/pages/api/gyms/new.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import {
+  getGymDisplayName,
+  gymIsNew,
+  readGymState,
+  type GymRecord,
+} from "../../../lib/gyms";
+import { authOptions } from "../auth/[...nextauth]";
+
+interface NewGymItem extends GymRecord {
+  displayName: string;
+}
+
+type NewGymResponse = { gyms: NewGymItem[] } | { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<NewGymResponse>,
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+
+  const state = await readGymState();
+  const gyms = state.gyms
+    .filter((gym) => gymIsNew(gym))
+    .sort((left, right) =>
+      (right.firstSeenAt || "").localeCompare(left.firstSeenAt || ""),
+    )
+    .map((gym) => ({
+      ...gym,
+      displayName: getGymDisplayName(gym),
+    }));
+
+  res.setHeader("Cache-Control", "private, no-store");
+  return res.status(200).json({ gyms });
+}

--- a/pages/gyms.tsx
+++ b/pages/gyms.tsx
@@ -1,0 +1,81 @@
+import dynamic from "next/dynamic";
+import Head from "next/head";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import { readGymState, sortGyms } from "../lib/gyms";
+import { authOptions } from "./api/auth/[...nextauth]";
+
+const GymMap = dynamic(() => import("../components/gyms/GymMap"), {
+  ssr: false,
+  loading: () => <p className="gym-map-loading">Loading gym map…</p>,
+});
+
+interface GymPageProps {
+  gyms: Awaited<ReturnType<typeof readGymState>>["gyms"];
+  importedAt: string | null;
+}
+
+export const getServerSideProps: GetServerSideProps<GymPageProps> = async (
+  context,
+) => {
+  const session = await getServerSession(
+    context.req,
+    context.res,
+    authOptions as NextAuthOptions,
+  );
+
+  if (!session) {
+    const callbackUrl = encodeURIComponent(context.resolvedUrl || "/gyms");
+    return {
+      redirect: {
+        destination: `/login?callbackUrl=${callbackUrl}`,
+        permanent: false,
+      },
+    };
+  }
+
+  const state = await readGymState();
+
+  return {
+    props: {
+      gyms: sortGyms(state.gyms),
+      importedAt: state.importedAt,
+    },
+  };
+};
+
+export default function GymsPage({
+  gyms,
+  importedAt,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      <Head>
+        <title>Gym Map | Leigh Pokémon Go Community</title>
+        <meta
+          name="description"
+          content="Private community map of Pokémon GO gyms around Leigh and the surrounding area."
+        />
+      </Head>
+      <main className="container gyms-page">
+        <header className="gyms-header">
+          <div>
+            <p className="eyebrow">Members only</p>
+            <h1>Community gym map</h1>
+            <p>
+              Search official names and community aliases, find the nearest gyms,
+              and open turn-by-turn directions in Google Maps.
+            </p>
+          </div>
+          <div className="gym-legend" aria-label="Map legend">
+            <span><i className="standard" /> Gym</span>
+            <span><i className="ex" /> EX eligible</span>
+            <span><i className="new" /> Added in the last week</span>
+          </div>
+        </header>
+        <GymMap gyms={gyms} importedAt={importedAt} />
+      </main>
+    </>
+  );
+}

--- a/styles/gyms.css
+++ b/styles/gyms.css
@@ -1,0 +1,536 @@
+.gyms-page,
+.gym-admin-page {
+  padding-top: 28px;
+  padding-bottom: 60px;
+}
+
+.gyms-header,
+.gym-admin-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+  margin-bottom: 22px;
+}
+
+.gyms-header h1,
+.gym-admin-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.gyms-header > div > p:last-child,
+.gym-admin-header > div > p:last-child,
+.muted {
+  color: #8b949e;
+  line-height: 1.55;
+}
+
+.gyms-header .eyebrow,
+.gym-admin-header .eyebrow {
+  margin: 0 0 6px;
+  color: #3fb950;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.gym-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  padding: 12px;
+  border: 1px solid #30363d;
+  border-radius: 9px;
+  background: #161b22;
+  color: #c9d1d9;
+  font-size: 0.82rem;
+}
+
+.gym-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.gym-legend i {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #238636;
+}
+
+.gym-legend i.ex {
+  background: #8957e5;
+}
+
+.gym-legend i.new {
+  border: 2px solid #f2cc60;
+  background: rgba(242, 204, 96, 0.2);
+}
+
+.gym-map-layout {
+  display: grid;
+  grid-template-columns: minmax(250px, 340px) minmax(0, 1fr);
+  min-height: 640px;
+  overflow: hidden;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  background: #161b22;
+}
+
+.gym-map-sidebar {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  border-right: 1px solid #30363d;
+}
+
+.gym-map-controls {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid #30363d;
+}
+
+.gym-map-controls label,
+.alias-heading label,
+.alias-list label {
+  display: grid;
+  gap: 6px;
+  color: #f0f6fc;
+  font-weight: 700;
+}
+
+.gym-map-controls input,
+.gym-admin-page input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #30363d;
+  border-radius: 7px;
+  padding: 10px;
+  background: #0d1117;
+  color: #f0f6fc;
+  font: inherit;
+}
+
+.location-actions,
+.header-links,
+.upload-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.location-actions button,
+.upload-controls button,
+.alias-list button {
+  border: 0;
+  border-radius: 7px;
+  padding: 9px 12px;
+  background: #238636;
+  color: #fff;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.location-actions button.secondary {
+  border: 1px solid #30363d;
+  background: #21262d;
+}
+
+.location-actions button:disabled,
+.upload-controls button:disabled,
+.alias-list button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.gym-error {
+  margin: 0;
+  color: #ff7b72;
+}
+
+.gym-count {
+  display: grid;
+  gap: 3px;
+  margin: 0;
+  color: #f0f6fc;
+  font-weight: 800;
+}
+
+.gym-count small {
+  color: #8b949e;
+  font-weight: 400;
+}
+
+.gym-results {
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.gym-results > button {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid #21262d;
+  padding: 11px 13px;
+  background: transparent;
+  color: #c9d1d9;
+  text-align: left;
+  cursor: pointer;
+}
+
+.gym-results > button:hover,
+.gym-results > button:focus-visible,
+.gym-results > button.selected {
+  background: #1f2937;
+  outline: none;
+}
+
+.gym-results > button.selected {
+  box-shadow: inset 4px 0 #58a6ff;
+}
+
+.gym-results > button > span:first-child {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.gym-results strong,
+.gym-results small {
+  overflow-wrap: anywhere;
+}
+
+.gym-results small {
+  color: #8b949e;
+}
+
+.gym-result-meta {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 4px;
+  justify-items: end;
+}
+
+.gym-result-meta em,
+.new-badge {
+  border-radius: 999px;
+  padding: 3px 7px;
+  background: rgba(242, 204, 96, 0.16);
+  color: #f2cc60;
+  font-size: 0.72rem;
+  font-style: normal;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.result-limit {
+  margin: 0;
+  padding: 12px;
+  color: #8b949e;
+  font-size: 0.82rem;
+}
+
+.gym-map-panel,
+.gym-leaflet-map {
+  min-height: 640px;
+}
+
+.gym-leaflet-map {
+  width: 100%;
+  height: 100%;
+  background: #0d1117;
+}
+
+.gym-popup {
+  display: grid;
+  gap: 7px;
+  min-width: 180px;
+}
+
+.gym-popup strong {
+  font-size: 1rem;
+}
+
+.gym-popup small,
+.gym-popup span {
+  color: #57606a;
+}
+
+.gym-popup a {
+  margin-top: 3px;
+  color: #0969da;
+  font-weight: 700;
+}
+
+.new-gym-aura {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: gym-aura-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes gym-aura-pulse {
+  0%, 100% { transform: scale(0.92); }
+  50% { transform: scale(1.08); }
+}
+
+.gym-empty,
+.gym-map-loading {
+  padding: 28px;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  background: #161b22;
+}
+
+.new-gym-ticker {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 49px;
+  overflow: hidden;
+  border-top: 1px solid #6e5500;
+  border-bottom: 1px solid #6e5500;
+  background: linear-gradient(90deg, #2d2400, #161b22 32%, #161b22);
+  color: #f0f6fc;
+}
+
+.new-gym-label {
+  display: flex;
+  z-index: 2;
+  align-items: center;
+  gap: 9px;
+  padding: 0 20px;
+  background: #2d2400;
+  color: #f2cc60;
+  font-size: 0.96rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.new-gym-viewport {
+  overflow: hidden;
+}
+
+.new-gym-track {
+  display: flex;
+  width: max-content;
+  min-width: 100%;
+  animation: new-gym-scroll 32s linear infinite;
+}
+
+.new-gym-ticker:hover .new-gym-track,
+.new-gym-ticker:focus-within .new-gym-track {
+  animation-play-state: paused;
+}
+
+.new-gym-copy {
+  display: flex;
+  min-width: max-content;
+}
+
+.new-gym-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 23px;
+  color: #f0f6fc;
+  font-size: 1.07rem;
+  line-height: 49px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.new-gym-item::after {
+  margin-left: 12px;
+  color: #f2cc60;
+  content: "◆";
+  font-size: 0.64rem;
+}
+
+.new-gym-item .official-name {
+  color: #8b949e;
+  font-size: 0.9rem;
+}
+
+@keyframes new-gym-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+.gym-admin-header .header-links a {
+  color: #58a6ff;
+}
+
+.gym-notice {
+  padding: 11px 14px;
+  border-radius: 8px;
+}
+
+.gym-notice.success {
+  border: 1px solid #238636;
+  background: rgba(35, 134, 54, 0.15);
+}
+
+.gym-notice.error {
+  border: 1px solid #f85149;
+  background: rgba(248, 81, 73, 0.12);
+}
+
+.gym-admin-card {
+  margin-bottom: 18px;
+  padding: 22px;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  background: #161b22;
+}
+
+.gym-admin-card h2 {
+  margin-top: 0;
+}
+
+.gym-admin-card code {
+  color: #79c0ff;
+}
+
+.uploader-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.65fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.upload-controls {
+  display: grid;
+}
+
+.import-status {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.import-status div {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  background: #0d1117;
+}
+
+.import-status dt {
+  color: #8b949e;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.import-status dd {
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+  color: #f0f6fc;
+}
+
+.alias-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: end;
+  margin-bottom: 16px;
+}
+
+.alias-heading label {
+  min-width: min(320px, 100%);
+}
+
+.alias-list {
+  display: grid;
+  gap: 9px;
+}
+
+.alias-list article {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(240px, 1fr) auto;
+  gap: 12px;
+  align-items: end;
+  padding: 12px;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  background: #0d1117;
+}
+
+.gym-identity {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.gym-identity strong,
+.gym-identity small {
+  overflow-wrap: anywhere;
+}
+
+.gym-identity small {
+  color: #8b949e;
+}
+
+@media (max-width: 900px) {
+  .gyms-header,
+  .gym-admin-header,
+  .alias-heading {
+    display: grid;
+  }
+
+  .gym-map-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .gym-map-sidebar {
+    max-height: 420px;
+    border-right: 0;
+    border-bottom: 1px solid #30363d;
+  }
+
+  .gym-map-panel,
+  .gym-leaflet-map {
+    min-height: 520px;
+  }
+
+  .uploader-card,
+  .alias-list article {
+    grid-template-columns: 1fr;
+  }
+
+  .import-status {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .new-gym-label {
+    padding: 0 13px;
+    font-size: 0.88rem;
+  }
+
+  .new-gym-item {
+    padding: 0 18px;
+    font-size: 1rem;
+  }
+
+  .gym-map-panel,
+  .gym-leaflet-map {
+    min-height: 460px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .new-gym-track,
+  .new-gym-aura {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Adds the members-only gym map and complete admin CSV workflow.

- Gym Map is hidden from logged-out navigation and redirects unauthenticated access to login.
- Authenticated gym APIs reject unauthenticated requests.
- Admin → Gym Data accepts the supplied gym CSV structure and archives every accepted upload under `data/gym-imports`.
- Archive names use UK local time in the format `YYYY-MM-DD HH-mm-ss - gyms.csv`.
- The first upload establishes the baseline; later uploads identify new, updated and removed gyms.
- Community aliases are editable and survive later CSV uploads by gym ID.
- Map search supports official names and aliases.
- `Gyms near me` uses browser location only after the member presses the button.
- Every gym has a Google Maps directions link.
- Newly added gyms receive a gradually fading seven-day aura and appear in a members-only ticker below Current raids.
- Raw CSV imports and the generated gym state are ignored by Git.
- No database migration is involved.

Validation passed: dependency lockfile update, clean dependency installation, production build, CSV parser handling for quoted commas, authenticated feature wiring, UK archive timestamp checks, alias preservation wiring and generated-build-file cleanup.