### PR TITLE
Allow members to add gyms by GPS or manual coordinates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,36 @@
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - feature/member-gym-addition
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: file:./prisma/ci.db
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ci-only-secret
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --runInBand
+
+      - name: Build production application
+        run: npm run build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DATABASE_URL: file:./prisma/ci.db
+      DATABASE_URL: file:./ci.db
       NEXTAUTH_URL: http://localhost:3000
       NEXTAUTH_SECRET: ci-only-secret
     steps:

--- a/__tests__/api/gyms-create.test.js
+++ b/__tests__/api/gyms-create.test.js
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for /api/gyms/create.
+ * Run with: npm test
+ */
+
+const { createMocks } = require("node-mocks-http");
+const { getServerSession } = require("next-auth/next");
+
+jest.mock("node:crypto", () => ({
+  randomUUID: jest.fn(() => "test-gym-id"),
+}));
+
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+jest.mock("../../lib/gyms", () => ({
+  readGymState: jest.fn(),
+  writeGymState: jest.fn(),
+  sortGyms: jest.fn((gyms) => gyms),
+}));
+
+const {
+  readGymState,
+  writeGymState,
+} = require("../../lib/gyms");
+const handler = require("../../pages/api/gyms/create").default;
+
+const emptyState = {
+  version: 1,
+  importedAt: null,
+  sourceFile: null,
+  gyms: [],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  readGymState.mockResolvedValue(emptyState);
+  writeGymState.mockResolvedValue(undefined);
+});
+
+describe("POST /api/gyms/create", () => {
+  it("rejects logged-out requests", async () => {
+    getServerSession.mockResolvedValueOnce(null);
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { title: "Test Gym", lat: 53.49, lon: -2.52 },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "Authentication required",
+    });
+    expect(writeGymState).not.toHaveBeenCalled();
+  });
+
+  it("creates a gym from valid coordinates", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 1, ign: "gaz", role: "user" },
+    });
+    const { req, res } = createMocks({
+      method: "POST",
+      body: {
+        title: "  Leigh   Cenotaph  ",
+        lat: "53.496",
+        lon: "-2.519",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    const payload = JSON.parse(res._getData());
+    expect(payload.message).toBe("Gym added successfully.");
+    expect(payload.gym).toEqual(
+      expect.objectContaining({
+        id: "community-test-gym-id",
+        name: "Leigh Cenotaph",
+        lat: 53.496,
+        lon: -2.519,
+        alias: null,
+        url: null,
+        exRaidEligible: false,
+        firstSeenAt: expect.any(String),
+      }),
+    );
+    expect(writeGymState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 1,
+        gyms: [expect.objectContaining({ id: "community-test-gym-id" })],
+      }),
+    );
+  });
+
+  it("rejects coordinates outside the valid range", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 1, ign: "gaz", role: "user" },
+    });
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { title: "Test Gym", lat: 91, lon: -2.52 },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "The latitude is invalid.",
+    });
+    expect(writeGymState).not.toHaveBeenCalled();
+  });
+
+  it("rejects a blank gym title", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 1, ign: "gaz", role: "user" },
+    });
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { title: "   ", lat: 53.49, lon: -2.52 },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "Enter a title for the gym.",
+    });
+    expect(writeGymState).not.toHaveBeenCalled();
+  });
+});

--- a/components/gyms/AddGymForm.module.css
+++ b/components/gyms/AddGymForm.module.css
@@ -29,7 +29,8 @@
 }
 
 .primary,
-.secondary {
+.secondary,
+.methodButton {
   border-radius: 7px;
   padding: 10px 14px;
   font: inherit;
@@ -43,14 +44,16 @@
   color: #fff;
 }
 
-.secondary {
+.secondary,
+.methodButton {
   border: 1px solid #30363d;
   background: #21262d;
   color: #f0f6fc;
 }
 
 .primary:disabled,
-.secondary:disabled {
+.secondary:disabled,
+.methodButton:disabled {
   opacity: 0.6;
   cursor: wait;
 }
@@ -104,14 +107,37 @@
   font: inherit;
 }
 
-.locationStatus {
+.locationMethods {
   display: grid;
-  gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.methodButton {
+  text-align: center;
+}
+
+.methodActive {
+  border-color: #58a6ff;
+  background: rgba(88, 166, 255, 0.14);
+  color: #79c0ff;
+}
+
+.locationStatus,
+.manualLocation {
+  display: grid;
+  gap: 8px;
   padding: 12px;
   border: 1px solid #30363d;
   border-radius: 8px;
   background: #0d1117;
   color: #f0f6fc;
+}
+
+.coordinateGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
 }
 
 .error {
@@ -126,11 +152,15 @@
 
 @media (max-width: 700px) {
   .launch,
-  .formHeader {
+  .formHeader,
+  .locationMethods,
+  .coordinateGrid {
     display: grid;
+    grid-template-columns: 1fr;
   }
 
-  .launch .primary {
+  .launch .primary,
+  .methodButton {
     width: 100%;
   }
 }

--- a/components/gyms/AddGymForm.module.css
+++ b/components/gyms/AddGymForm.module.css
@@ -1,0 +1,136 @@
+.panel {
+  margin-bottom: 18px;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  background: #161b22;
+}
+
+.launch {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 18px;
+}
+
+.launchCopy {
+  display: grid;
+  gap: 3px;
+}
+
+.launchCopy strong {
+  color: #f0f6fc;
+}
+
+.launchCopy span,
+.help,
+.locationStatus small {
+  color: #8b949e;
+}
+
+.primary,
+.secondary {
+  border-radius: 7px;
+  padding: 10px 14px;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.primary {
+  border: 0;
+  background: #238636;
+  color: #fff;
+}
+
+.secondary {
+  border: 1px solid #30363d;
+  background: #21262d;
+  color: #f0f6fc;
+}
+
+.primary:disabled,
+.secondary:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.form {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-top: 1px solid #30363d;
+}
+
+.formHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.formHeader h2 {
+  margin: 0 0 4px;
+  color: #f0f6fc;
+  font-size: 1.15rem;
+}
+
+.formHeader p,
+.help,
+.error {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.formHeader p {
+  color: #8b949e;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  color: #f0f6fc;
+  font-weight: 700;
+}
+
+.field input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #30363d;
+  border-radius: 7px;
+  padding: 10px;
+  background: #0d1117;
+  color: #f0f6fc;
+  font: inherit;
+}
+
+.locationStatus {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  background: #0d1117;
+  color: #f0f6fc;
+}
+
+.error {
+  color: #ff7b72;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 700px) {
+  .launch,
+  .formHeader {
+    display: grid;
+  }
+
+  .launch .primary {
+    width: 100%;
+  }
+}

--- a/components/gyms/AddGymForm.tsx
+++ b/components/gyms/AddGymForm.tsx
@@ -1,0 +1,227 @@
+import { useState, type FormEvent } from "react";
+import styles from "./AddGymForm.module.css";
+
+interface CapturedLocation {
+  lat: number;
+  lon: number;
+  accuracy: number;
+}
+
+interface CreatedGym {
+  id: string;
+}
+
+type CreateGymResponse =
+  | { message: string; gym: CreatedGym }
+  | { error: string };
+
+function geolocationErrorMessage(error: GeolocationPositionError): string {
+  if (error.code === error.PERMISSION_DENIED) {
+    return "Location access is blocked for this site. Open your browser's site permissions, change Location to Allow, then press Try location again.";
+  }
+
+  if (error.code === error.POSITION_UNAVAILABLE) {
+    return "Your device could not provide a GPS position. Make sure device Location is switched on, then try again.";
+  }
+
+  if (error.code === error.TIMEOUT) {
+    return "The GPS request timed out before your device found a position. Move somewhere with a clearer signal and try again.";
+  }
+
+  return "Your current GPS location could not be determined. Please try again.";
+}
+
+export default function AddGymForm() {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [location, setLocation] = useState<CapturedLocation | null>(null);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [locating, setLocating] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  function requestLocation() {
+    setLocationError(null);
+    setSubmitError(null);
+
+    if (!window.isSecureContext) {
+      setLocationError(
+        "Your browser blocks GPS on non-secure pages. Open the HTTPS version of this site, then try again.",
+      );
+      return;
+    }
+
+    if (!navigator.geolocation) {
+      setLocationError("Location is not supported by this browser or device.");
+      return;
+    }
+
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLocation({
+          lat: position.coords.latitude,
+          lon: position.coords.longitude,
+          accuracy: position.coords.accuracy,
+        });
+        setLocating(false);
+      },
+      (error) => {
+        setLocation(null);
+        setLocationError(geolocationErrorMessage(error));
+        setLocating(false);
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 15_000,
+        maximumAge: 0,
+      },
+    );
+  }
+
+  function startAdding() {
+    setOpen(true);
+    setLocation(null);
+    setLocationError(null);
+    setSubmitError(null);
+    requestLocation();
+  }
+
+  function cancel() {
+    setOpen(false);
+    setTitle("");
+    setLocation(null);
+    setLocationError(null);
+    setSubmitError(null);
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitError(null);
+
+    const cleanedTitle = title.trim();
+
+    if (!cleanedTitle) {
+      setSubmitError("Enter a title for the gym.");
+      return;
+    }
+
+    if (!location) {
+      setSubmitError("A current GPS location is required before the gym can be added.");
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      const response = await fetch("/api/gyms/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: cleanedTitle,
+          lat: location.lat,
+          lon: location.lon,
+        }),
+      });
+      const data = (await response.json()) as CreateGymResponse;
+
+      if (!response.ok || !("gym" in data)) {
+        throw new Error("error" in data ? data.error : "The gym could not be added.");
+      }
+
+      window.location.assign(`/gyms?gym=${encodeURIComponent(data.gym.id)}`);
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : "The gym could not be added.",
+      );
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className={styles.panel} aria-label="Add a gym">
+      {!open ? (
+        <div className={styles.launch}>
+          <div className={styles.launchCopy}>
+            <strong>Missing a gym?</strong>
+            <span>Add it using your device's current GPS position.</span>
+          </div>
+          <button type="button" className={styles.primary} onClick={startAdding}>
+            Add a gym at my location
+          </button>
+        </div>
+      ) : (
+        <form className={styles.form} onSubmit={submit}>
+          <div className={styles.formHeader}>
+            <div>
+              <h2>Add a gym</h2>
+              <p>The saved marker will use the GPS position reported by this device.</p>
+            </div>
+            <button
+              type="button"
+              className={styles.secondary}
+              onClick={cancel}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          </div>
+
+          <label className={styles.field}>
+            Gym title
+            <input
+              type="text"
+              value={title}
+              maxLength={120}
+              placeholder="For example, Leigh Cenotaph"
+              autoComplete="off"
+              required
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </label>
+
+          {location ? (
+            <div className={styles.locationStatus}>
+              <strong>GPS location captured</strong>
+              <span>
+                {location.lat.toFixed(6)}, {location.lon.toFixed(6)}
+              </span>
+              <small>Reported accuracy: about {Math.round(location.accuracy)} metres</small>
+            </div>
+          ) : (
+            <p className={styles.help}>
+              {locating
+                ? "Requesting your current GPS location…"
+                : "A current GPS location is required."}
+            </p>
+          )}
+
+          {locationError && <p className={styles.error}>{locationError}</p>}
+          {submitError && <p className={styles.error}>{submitError}</p>}
+
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.secondary}
+              onClick={requestLocation}
+              disabled={locating || saving}
+            >
+              {locating
+                ? "Finding location…"
+                : location
+                  ? "Refresh GPS location"
+                  : "Try location again"}
+            </button>
+            <button
+              type="submit"
+              className={styles.primary}
+              disabled={locating || saving || !location}
+            >
+              {saving ? "Adding gym…" : "Add gym"}
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/components/gyms/AddGymForm.tsx
+++ b/components/gyms/AddGymForm.tsx
@@ -11,30 +11,52 @@ interface CreatedGym {
   id: string;
 }
 
+type LocationMode = "gps" | "manual";
+
 type CreateGymResponse =
   | { message: string; gym: CreatedGym }
   | { error: string };
 
 function geolocationErrorMessage(error: GeolocationPositionError): string {
   if (error.code === error.PERMISSION_DENIED) {
-    return "Location access is blocked for this site. Open your browser's site permissions, change Location to Allow, then press Try location again.";
+    return "Location access is blocked for this site. Open your browser's site permissions, change Location to Allow, then press Try location again. You can also set the location manually.";
   }
 
   if (error.code === error.POSITION_UNAVAILABLE) {
-    return "Your device could not provide a GPS position. Make sure device Location is switched on, then try again.";
+    return "Your device could not provide a GPS position. Make sure device Location is switched on, then try again, or set the location manually.";
   }
 
   if (error.code === error.TIMEOUT) {
-    return "The GPS request timed out before your device found a position. Move somewhere with a clearer signal and try again.";
+    return "The GPS request timed out before your device found a position. Move somewhere with a clearer signal and try again, or set the location manually.";
   }
 
-  return "Your current GPS location could not be determined. Please try again.";
+  return "Your current GPS location could not be determined. Try again or set the location manually.";
+}
+
+function manualCoordinate(
+  value: string,
+  field: "latitude" | "longitude",
+): number {
+  const coordinate = Number(value.trim());
+  const minimum = field === "latitude" ? -90 : -180;
+  const maximum = field === "latitude" ? 90 : 180;
+
+  if (!Number.isFinite(coordinate) || coordinate < minimum || coordinate > maximum) {
+    throw new Error(
+      `Enter a valid ${field} between ${minimum} and ${maximum}.`,
+    );
+  }
+
+  return coordinate;
 }
 
 export default function AddGymForm() {
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState("");
-  const [location, setLocation] = useState<CapturedLocation | null>(null);
+  const [locationMode, setLocationMode] = useState<LocationMode>("gps");
+  const [gpsLocation, setGpsLocation] = useState<CapturedLocation | null>(null);
+  const [manualLatitude, setManualLatitude] = useState("");
+  const [manualLongitude, setManualLongitude] = useState("");
   const [locationError, setLocationError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [locating, setLocating] = useState(false);
@@ -46,20 +68,22 @@ export default function AddGymForm() {
 
     if (!window.isSecureContext) {
       setLocationError(
-        "Your browser blocks GPS on non-secure pages. Open the HTTPS version of this site, then try again.",
+        "Your browser blocks GPS on non-secure pages. Open the HTTPS version of this site and try again, or set the location manually.",
       );
       return;
     }
 
     if (!navigator.geolocation) {
-      setLocationError("Location is not supported by this browser or device.");
+      setLocationError(
+        "Location is not supported by this browser or device. Set the location manually instead.",
+      );
       return;
     }
 
     setLocating(true);
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        setLocation({
+        setGpsLocation({
           lat: position.coords.latitude,
           lon: position.coords.longitude,
           accuracy: position.coords.accuracy,
@@ -67,7 +91,7 @@ export default function AddGymForm() {
         setLocating(false);
       },
       (error) => {
-        setLocation(null);
+        setGpsLocation(null);
         setLocationError(geolocationErrorMessage(error));
         setLocating(false);
       },
@@ -81,18 +105,38 @@ export default function AddGymForm() {
 
   function startAdding() {
     setOpen(true);
-    setLocation(null);
+    setLocationMode("gps");
+    setGpsLocation(null);
+    setManualLatitude("");
+    setManualLongitude("");
     setLocationError(null);
     setSubmitError(null);
     requestLocation();
   }
 
+  function chooseGps() {
+    setLocationMode("gps");
+    setSubmitError(null);
+    requestLocation();
+  }
+
+  function chooseManual() {
+    setLocationMode("manual");
+    setLocationError(null);
+    setSubmitError(null);
+  }
+
   function cancel() {
     setOpen(false);
     setTitle("");
-    setLocation(null);
+    setLocationMode("gps");
+    setGpsLocation(null);
+    setManualLatitude("");
+    setManualLongitude("");
     setLocationError(null);
     setSubmitError(null);
+    setLocating(false);
+    setSaving(false);
   }
 
   async function submit(event: FormEvent<HTMLFormElement>) {
@@ -106,8 +150,26 @@ export default function AddGymForm() {
       return;
     }
 
-    if (!location) {
-      setSubmitError("A current GPS location is required before the gym can be added.");
+    let lat: number;
+    let lon: number;
+
+    try {
+      if (locationMode === "manual") {
+        lat = manualCoordinate(manualLatitude, "latitude");
+        lon = manualCoordinate(manualLongitude, "longitude");
+      } else if (gpsLocation) {
+        lat = gpsLocation.lat;
+        lon = gpsLocation.lon;
+      } else {
+        setSubmitError(
+          "Capture a GPS location or choose Set location manually.",
+        );
+        return;
+      }
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : "Enter valid coordinates.",
+      );
       return;
     }
 
@@ -119,8 +181,8 @@ export default function AddGymForm() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: cleanedTitle,
-          lat: location.lat,
-          lon: location.lon,
+          lat,
+          lon,
         }),
       });
       const data = (await response.json()) as CreateGymResponse;
@@ -144,10 +206,10 @@ export default function AddGymForm() {
         <div className={styles.launch}>
           <div className={styles.launchCopy}>
             <strong>Missing a gym?</strong>
-            <span>Add it using your device's current GPS position.</span>
+            <span>Use your device GPS or enter its coordinates manually.</span>
           </div>
           <button type="button" className={styles.primary} onClick={startAdding}>
-            Add a gym at my location
+            Add a gym
           </button>
         </div>
       ) : (
@@ -155,7 +217,7 @@ export default function AddGymForm() {
           <div className={styles.formHeader}>
             <div>
               <h2>Add a gym</h2>
-              <p>The saved marker will use the GPS position reported by this device.</p>
+              <p>Choose device GPS or enter the marker coordinates manually.</p>
             </div>
             <button
               type="button"
@@ -180,42 +242,108 @@ export default function AddGymForm() {
             />
           </label>
 
-          {location ? (
-            <div className={styles.locationStatus}>
-              <strong>GPS location captured</strong>
-              <span>
-                {location.lat.toFixed(6)}, {location.lon.toFixed(6)}
-              </span>
-              <small>Reported accuracy: about {Math.round(location.accuracy)} metres</small>
-            </div>
+          <div className={styles.locationMethods} role="group" aria-label="Location method">
+            <button
+              type="button"
+              className={`${styles.methodButton} ${locationMode === "gps" ? styles.methodActive : ""}`}
+              onClick={chooseGps}
+              disabled={saving || (locationMode === "gps" && locating)}
+            >
+              Use device GPS
+            </button>
+            <button
+              type="button"
+              className={`${styles.methodButton} ${locationMode === "manual" ? styles.methodActive : ""}`}
+              onClick={chooseManual}
+              disabled={saving}
+            >
+              Set location manually
+            </button>
+          </div>
+
+          {locationMode === "gps" ? (
+            <>
+              {gpsLocation ? (
+                <div className={styles.locationStatus}>
+                  <strong>GPS location captured</strong>
+                  <span>
+                    {gpsLocation.lat.toFixed(6)}, {gpsLocation.lon.toFixed(6)}
+                  </span>
+                  <small>
+                    Reported accuracy: about {Math.round(gpsLocation.accuracy)} metres
+                  </small>
+                </div>
+              ) : (
+                <p className={styles.help}>
+                  {locating
+                    ? "Requesting your current GPS location…"
+                    : "A GPS location has not been captured."}
+                </p>
+              )}
+
+              {locationError && <p className={styles.error}>{locationError}</p>}
+
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={requestLocation}
+                disabled={locating || saving}
+              >
+                {locating
+                  ? "Finding location…"
+                  : gpsLocation
+                    ? "Refresh GPS location"
+                    : "Try location again"}
+              </button>
+            </>
           ) : (
-            <p className={styles.help}>
-              {locating
-                ? "Requesting your current GPS location…"
-                : "A current GPS location is required."}
-            </p>
+            <div className={styles.manualLocation}>
+              <p className={styles.help}>
+                Enter decimal coordinates. In Google Maps, press and hold the gym location to drop a pin and copy its latitude and longitude.
+              </p>
+              <div className={styles.coordinateGrid}>
+                <label className={styles.field}>
+                  Latitude
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    step="any"
+                    min="-90"
+                    max="90"
+                    value={manualLatitude}
+                    placeholder="53.496000"
+                    required={locationMode === "manual"}
+                    onChange={(event) => setManualLatitude(event.target.value)}
+                  />
+                </label>
+                <label className={styles.field}>
+                  Longitude
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    step="any"
+                    min="-180"
+                    max="180"
+                    value={manualLongitude}
+                    placeholder="-2.519000"
+                    required={locationMode === "manual"}
+                    onChange={(event) => setManualLongitude(event.target.value)}
+                  />
+                </label>
+              </div>
+            </div>
           )}
 
-          {locationError && <p className={styles.error}>{locationError}</p>}
           {submitError && <p className={styles.error}>{submitError}</p>}
 
           <div className={styles.actions}>
             <button
-              type="button"
-              className={styles.secondary}
-              onClick={requestLocation}
-              disabled={locating || saving}
-            >
-              {locating
-                ? "Finding location…"
-                : location
-                  ? "Refresh GPS location"
-                  : "Try location again"}
-            </button>
-            <button
               type="submit"
               className={styles.primary}
-              disabled={locating || saving || !location}
+              disabled={
+                saving ||
+                (locationMode === "gps" && (locating || !gpsLocation))
+              }
             >
               {saving ? "Adding gym…" : "Add gym"}
             </button>

--- a/lib/communityGyms.ts
+++ b/lib/communityGyms.ts
@@ -1,0 +1,25 @@
+import type { GymRecord } from "./gyms";
+
+export const COMMUNITY_GYM_ID_PREFIX = "community-";
+
+export function isCommunityGym(gym: Pick<GymRecord, "id">): boolean {
+  return gym.id.startsWith(COMMUNITY_GYM_ID_PREFIX);
+}
+
+export function cleanCommunityGymTitle(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error("Enter a title for the gym.");
+  }
+
+  const title = value.trim().replace(/\s+/g, " ");
+
+  if (!title) {
+    throw new Error("Enter a title for the gym.");
+  }
+
+  if (title.length > 120) {
+    throw new Error("Gym titles must be 120 characters or fewer.");
+  }
+
+  return title;
+}

--- a/pages/api/admin/gyms/upload.ts
+++ b/pages/api/admin/gyms/upload.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { NextAuthOptions } from "next-auth";
 import { getServerSession } from "next-auth/next";
 import { parse } from "csv-parse/sync";
+import { isCommunityGym } from "../../../../lib/communityGyms";
 import {
   readGymState,
   writeGymState,
@@ -244,15 +245,17 @@ export default async function handler(
     const buffer = decodeCsv(req.body as UploadBody);
     const importedGyms = parseGyms(buffer);
     const previous = await readGymState();
-    const previousById = new Map(previous.gyms.map((gym) => [gym.id, gym]));
+    const previousImportedGyms = previous.gyms.filter((gym) => !isCommunityGym(gym));
+    const communityGyms = previous.gyms.filter(isCommunityGym);
+    const previousById = new Map(previousImportedGyms.map((gym) => [gym.id, gym]));
     const importedAtDate = new Date();
     const importedAt = importedAtDate.toISOString();
-    const initialImport = previous.gyms.length === 0;
+    const initialImport = previousImportedGyms.length === 0;
     let added = 0;
     let updated = 0;
     let unchanged = 0;
 
-    const gyms: GymRecord[] = importedGyms.map((gym) => {
+    const importedGymRecords: GymRecord[] = importedGyms.map((gym) => {
       const existing = previousById.get(gym.id);
 
       if (!existing) {
@@ -277,8 +280,14 @@ export default async function handler(
       };
     });
 
-    const importedIds = new Set(gyms.map((gym) => gym.id));
-    const removed = previous.gyms.filter((gym) => !importedIds.has(gym.id)).length;
+    const importedIds = new Set(importedGymRecords.map((gym) => gym.id));
+    const preservedCommunityGyms = communityGyms.filter(
+      (gym) => !importedIds.has(gym.id),
+    );
+    const gyms = [...importedGymRecords, ...preservedCommunityGyms];
+    const removed = previousImportedGyms.filter(
+      (gym) => !importedIds.has(gym.id),
+    ).length;
     const sourceFile = await archiveCsv(buffer, importedAtDate);
 
     await writeGymState({

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "./auth/[...nextauth]";
-import prisma from "../../lib/prisma"; // adjust path if needed
+import prisma from "../../lib/prisma";
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions);
@@ -32,7 +32,7 @@ export default async function handler(req, res) {
           ownerId: session.user.id,
         },
         include: {
-          owner: { select: { id: true, ign: true, role: true, team: true, friendCode: true } },
+          owner: { select: { id: true, ign: true, role: true } },
         },
       });
 
@@ -46,7 +46,7 @@ export default async function handler(req, res) {
   if (req.method === "GET") {
     try {
       const entries = await prisma.entry.findMany({
-        include: { owner: { select: { id: true, ign: true, team: true, friendCode: true } } },
+        include: { owner: { select: { id: true, ign: true } } },
         orderBy: { createdAt: "desc" },
       });
       return res.status(200).json(entries);

--- a/pages/api/gyms/create.ts
+++ b/pages/api/gyms/create.ts
@@ -33,7 +33,7 @@ function coordinate(
   const maximum = field === "latitude" ? 90 : 180;
 
   if (!Number.isFinite(number) || number < minimum || number > maximum) {
-    throw new Error(`The GPS ${field} is invalid.`);
+    throw new Error(`The ${field} is invalid.`);
   }
 
   return number;
@@ -79,7 +79,7 @@ export default async function handler(
 
     res.setHeader("Cache-Control", "private, no-store");
     return res.status(201).json({
-      message: "Gym added at your current location.",
+      message: "Gym added successfully.",
       gym,
     });
   } catch (error) {

--- a/pages/api/gyms/create.ts
+++ b/pages/api/gyms/create.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import {
+  cleanCommunityGymTitle,
+  COMMUNITY_GYM_ID_PREFIX,
+} from "../../../lib/communityGyms";
+import {
+  readGymState,
+  sortGyms,
+  writeGymState,
+  type GymRecord,
+} from "../../../lib/gyms";
+import { authOptions } from "../auth/[...nextauth]";
+
+interface CreateGymBody {
+  title?: unknown;
+  lat?: unknown;
+  lon?: unknown;
+}
+
+type CreateGymResponse =
+  | { message: string; gym: GymRecord }
+  | { error: string };
+
+function coordinate(
+  value: unknown,
+  field: "latitude" | "longitude",
+): number {
+  const number = Number(value);
+  const minimum = field === "latitude" ? -90 : -180;
+  const maximum = field === "latitude" ? 90 : 180;
+
+  if (!Number.isFinite(number) || number < minimum || number > maximum) {
+    throw new Error(`The GPS ${field} is invalid.`);
+  }
+
+  return number;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CreateGymResponse>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+
+  try {
+    const body = req.body as CreateGymBody;
+    const title = cleanCommunityGymTitle(body.title);
+    const lat = coordinate(body.lat, "latitude");
+    const lon = coordinate(body.lon, "longitude");
+    const createdAt = new Date().toISOString();
+    const gym: GymRecord = {
+      id: `${COMMUNITY_GYM_ID_PREFIX}${randomUUID()}`,
+      name: title,
+      alias: null,
+      url: null,
+      lat,
+      lon,
+      exRaidEligible: false,
+      firstSeenAt: createdAt,
+    };
+    const state = await readGymState();
+
+    await writeGymState({
+      ...state,
+      gyms: sortGyms([...state.gyms, gym]),
+    });
+
+    res.setHeader("Cache-Control", "private, no-store");
+    return res.status(201).json({
+      message: "Gym added at your current location.",
+      gym,
+    });
+  } catch (error) {
+    return res.status(400).json({
+      error: error instanceof Error ? error.message : "The gym could not be added.",
+    });
+  }
+}

--- a/pages/gyms.tsx
+++ b/pages/gyms.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import type { NextAuthOptions } from "next-auth";
 import { getServerSession } from "next-auth/next";
+import AddGymForm from "../components/gyms/AddGymForm";
 import { readGymState, sortGyms } from "../lib/gyms";
 import { authOptions } from "./api/auth/[...nextauth]";
 
@@ -65,7 +66,8 @@ export default function GymsPage({
             <h1>Community gym map</h1>
             <p>
               Search official names and community aliases, find the nearest gyms,
-              and open turn-by-turn directions in Google Maps.
+              add missing gyms from your current GPS location, and open turn-by-turn
+              directions in Google Maps.
             </p>
           </div>
           <div className="gym-legend" aria-label="Map legend">
@@ -74,6 +76,7 @@ export default function GymsPage({
             <span><i className="new" /> Added in the last week</span>
           </div>
         </header>
+        <AddGymForm />
         <GymMap gyms={gyms} importedAt={importedAt} />
       </main>
     </>


### PR DESCRIPTION
## What changed

- Adds a members-only **Add a gym** panel above the gym map.
- Uses a fresh high-accuracy device GPS position by default and displays the reported coordinates and accuracy.
- Adds a **Set location manually** option with validated decimal latitude and longitude fields.
- Requires a gym title and validates the title and coordinates on both the client and server.
- Explains insecure-context, blocked-permission, unavailable-position and timeout failures.
- Provides a **Try location again** action so a member can re-enable browser location permission and retry.
- Adds an authenticated gym-creation API; logged-out requests are rejected.
- Marks member-added gyms with generated `community-` IDs and preserves those entries through later admin CSV imports.
- Sets `firstSeenAt` when a member adds a gym, so the existing seven-day new-gym aura and ticker apply automatically.
- Reloads the map focused on the newly added gym after a successful submission.
- Fixes the existing entries API querying removed `User.team` and `User.friendCode` fields, which was exposed by the full test run.
- Adds GitHub Actions validation for the Jest suite and production build.

## Behaviour notes

Browser GPS requires a secure context. Production HTTPS works normally; an insecure HTTP page explains that HTTPS is required for GPS while still allowing manual coordinate entry. Browser and manually entered coordinates are community contributions rather than trusted proof of physical presence.

## Validation

- `npm ci` passed on Node.js 20.
- Full Jest suite passed: 4 suites and 15 tests.
- The new gym-creation API tests cover authentication, successful coordinate submission, invalid coordinate rejection and blank-title rejection.
- `npm run build` completed successfully as a production Next.js build.
- Confirmed member-added records are excluded from CSV removal calculations and retained in the written gym state.