### PR TITLE
Add member gym removal reports and admin approval

### DIFF
--- a/__tests__/api/admin-gym-removal-reports.test.js
+++ b/__tests__/api/admin-gym-removal-reports.test.js
@@ -1,0 +1,135 @@
+/**
+ * Integration tests for /api/admin/gyms/removal-reports.
+ */
+
+const { createMocks } = require("node-mocks-http");
+const { getServerSession } = require("next-auth/next");
+
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+jest.mock("../../lib/gyms", () => ({
+  readGymState: jest.fn(),
+  writeGymState: jest.fn(),
+}));
+
+const { readGymState, writeGymState } = require("../../lib/gyms");
+const handler = require("../../pages/api/admin/gyms/removal-reports").default;
+
+const gym = {
+  id: "gym-1",
+  name: "Test Gym",
+  alias: null,
+  url: null,
+  lat: 53.49,
+  lon: -2.52,
+  exRaidEligible: false,
+  firstSeenAt: null,
+};
+
+const report = {
+  id: "report-1",
+  gymId: gym.id,
+  gymName: gym.name,
+  reportedById: "12",
+  reportedByIgn: "MemberIGN",
+  reportedAt: "2026-07-31T10:00:00.000Z",
+  status: "pending",
+  reviewedAt: null,
+  reviewedById: null,
+  reviewedByIgn: null,
+};
+
+const state = {
+  version: 1,
+  importedAt: null,
+  sourceFile: null,
+  gyms: [gym],
+  removalReports: [report],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getServerSession.mockResolvedValue({
+    user: { id: 1, ign: "AdminIGN", role: "admin" },
+  });
+  readGymState.mockResolvedValue(state);
+  writeGymState.mockResolvedValue(undefined);
+});
+
+describe("/api/admin/gyms/removal-reports", () => {
+  it("rejects non-admin users", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 12, ign: "MemberIGN", role: "user" },
+    });
+    const { req, res } = createMocks({ method: "GET" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(writeGymState).not.toHaveBeenCalled();
+  });
+
+  it("returns pending reports", async () => {
+    const { req, res } = createMocks({ method: "GET" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData()).reports).toEqual([report]);
+  });
+
+  it("approves a report and removes the gym atomically", async () => {
+    const { req, res } = createMocks({
+      method: "PATCH",
+      body: { reportId: report.id, decision: "approve" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(writeGymState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gyms: [],
+        removalReports: [
+          expect.objectContaining({
+            id: report.id,
+            status: "approved",
+            reviewedById: "1",
+            reviewedByIgn: "AdminIGN",
+            reviewedAt: expect.any(String),
+          }),
+        ],
+      }),
+    );
+    expect(JSON.parse(res._getData()).gymRemoved).toBe(true);
+  });
+
+  it("rejects a report without removing the gym", async () => {
+    const { req, res } = createMocks({
+      method: "PATCH",
+      body: { reportId: report.id, decision: "reject" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(writeGymState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gyms: [gym],
+        removalReports: [
+          expect.objectContaining({
+            id: report.id,
+            status: "rejected",
+          }),
+        ],
+      }),
+    );
+    expect(JSON.parse(res._getData()).gymRemoved).toBe(false);
+  });
+});

--- a/__tests__/api/gyms-report-removed.test.js
+++ b/__tests__/api/gyms-report-removed.test.js
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for /api/gyms/report-removed.
+ */
+
+const { createMocks } = require("node-mocks-http");
+const { getServerSession } = require("next-auth/next");
+
+jest.mock("node:crypto", () => ({
+  randomUUID: jest.fn(() => "removal-report-id"),
+}));
+
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+jest.mock("../../lib/gyms", () => ({
+  getGymDisplayName: jest.fn((gym) => gym.alias || gym.name),
+  readGymState: jest.fn(),
+  writeGymState: jest.fn(),
+}));
+
+const { readGymState, writeGymState } = require("../../lib/gyms");
+const handler = require("../../pages/api/gyms/report-removed").default;
+
+const gym = {
+  id: "gym-1",
+  name: "Official Gym Name",
+  alias: "Community Name",
+  url: null,
+  lat: 53.49,
+  lon: -2.52,
+  exRaidEligible: false,
+  firstSeenAt: null,
+};
+
+const state = {
+  version: 1,
+  importedAt: null,
+  sourceFile: null,
+  gyms: [gym],
+  removalReports: [],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  readGymState.mockResolvedValue(state);
+  writeGymState.mockResolvedValue(undefined);
+});
+
+describe("POST /api/gyms/report-removed", () => {
+  it("rejects logged-out requests", async () => {
+    getServerSession.mockResolvedValueOnce(null);
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { gymId: gym.id },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(writeGymState).not.toHaveBeenCalled();
+  });
+
+  it("creates a pending report for a logged-in member", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 12, ign: "MemberIGN", role: "user" },
+    });
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { gymId: gym.id },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    const payload = JSON.parse(res._getData());
+    expect(payload.report).toEqual(
+      expect.objectContaining({
+        id: "removal-report-id",
+        gymId: gym.id,
+        gymName: "Community Name",
+        reportedById: "12",
+        reportedByIgn: "MemberIGN",
+        status: "pending",
+      }),
+    );
+    expect(writeGymState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gyms: [gym],
+        removalReports: [
+          expect.objectContaining({
+            id: "removal-report-id",
+            gymId: gym.id,
+            status: "pending",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("does not create a duplicate pending report", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: 12, ign: "MemberIGN", role: "user" },
+    });
+    readGymState.mockResolvedValueOnce({
+      ...state,
+      removalReports: [
+        {
+          id: "existing-report",
+          gymId: gym.id,
+          gymName: gym.name,
+          reportedById: "7",
+          reportedByIgn: "OtherMember",
+          reportedAt: "2026-07-31T10:00:00.000Z",
+          status: "pending",
+          reviewedAt: null,
+          reviewedById: null,
+          reviewedByIgn: null,
+        },
+      ],
+    });
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { gymId: gym.id },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData()).report.id).toBe("existing-report");
+    expect(writeGymState).not.toHaveBeenCalled();
+  });
+});

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -138,6 +138,9 @@ export default function Navbar() {
                     <Link href="/admin/gyms" className="nav-item nav-subitem">
                       Gym Data
                     </Link>
+                    <Link href="/admin/gym-removals" className="nav-item nav-subitem">
+                      Gym Removals
+                    </Link>
                   </div>
                 </div>
               )}

--- a/components/gyms/GymRemovalReporter.module.css
+++ b/components/gyms/GymRemovalReporter.module.css
@@ -1,0 +1,39 @@
+.panel {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  margin-bottom: 14px;
+  padding: 14px 16px;
+  border: 1px solid #6e5500;
+  border-radius: 10px;
+  background: rgba(110, 85, 0, 0.18);
+}
+
+.panel > div:first-child {
+  min-width: 0;
+}
+
+.panel strong {
+  color: #f2cc60;
+}
+
+.panel p {
+  margin: 5px 0 0;
+  color: #c9d1d9;
+  line-height: 1.45;
+}
+
+.panel > div:last-child {
+  flex: 0 0 min(260px, 100%);
+}
+
+@media (max-width: 700px) {
+  .panel {
+    display: grid;
+  }
+
+  .panel > div:last-child {
+    width: 100%;
+  }
+}

--- a/components/gyms/GymRemovalReporter.tsx
+++ b/components/gyms/GymRemovalReporter.tsx
@@ -1,0 +1,43 @@
+import { useRouter } from "next/router";
+import ReportGymRemovedButton from "./ReportGymRemovedButton";
+import styles from "./GymRemovalReporter.module.css";
+
+interface ReportableGym {
+  id: string;
+  name: string;
+  alias: string | null;
+}
+
+interface GymRemovalReporterProps {
+  gyms: ReportableGym[];
+}
+
+export default function GymRemovalReporter({ gyms }: GymRemovalReporterProps) {
+  const router = useRouter();
+  const selectedId =
+    typeof router.query.gym === "string" ? router.query.gym : null;
+  const selectedGym = gyms.find((gym) => gym.id === selectedId) || null;
+
+  return (
+    <section className={styles.panel} aria-label="Report a removed gym">
+      <div>
+        <strong>Has a gym been removed?</strong>
+        {selectedGym ? (
+          <p>
+            Report <b>{selectedGym.alias || selectedGym.name}</b> for administrator
+            review. It will stay on the map until an admin approves removal.
+          </p>
+        ) : (
+          <p>Select a gym on the map or from the visible gym list first.</p>
+        )}
+      </div>
+      {selectedGym && (
+        <ReportGymRemovedButton
+          key={selectedGym.id}
+          gymId={selectedGym.id}
+          gymName={selectedGym.alias || selectedGym.name}
+        />
+      )}
+    </section>
+  );
+}

--- a/components/gyms/ReportGymRemovedButton.module.css
+++ b/components/gyms/ReportGymRemovedButton.module.css
@@ -1,0 +1,37 @@
+.reportControl {
+  display: grid;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.reportButton {
+  width: 100%;
+  border: 1px solid #d29922;
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: #fff8c5;
+  color: #7d4e00;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.reportButton:hover,
+.reportButton:focus-visible {
+  background: #fae17d;
+}
+
+.reportButton:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.success {
+  color: #1a7f37;
+  line-height: 1.35;
+}
+
+.error {
+  color: #cf222e;
+  line-height: 1.35;
+}

--- a/components/gyms/ReportGymRemovedButton.tsx
+++ b/components/gyms/ReportGymRemovedButton.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import styles from "./ReportGymRemovedButton.module.css";
+
+interface ReportGymRemovedButtonProps {
+  gymId: string;
+  gymName: string;
+}
+
+interface ReportResponse {
+  error?: string;
+  message?: string;
+}
+
+export default function ReportGymRemovedButton({
+  gymId,
+  gymName,
+}: ReportGymRemovedButtonProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function reportRemoved() {
+    if (
+      !window.confirm(
+        `Report “${gymName}” as removed? It will remain on the map until an administrator approves the report.`,
+      )
+    ) {
+      return;
+    }
+
+    setSubmitting(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/gyms/report-removed", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gymId }),
+      });
+      const payload = (await response.json()) as ReportResponse;
+
+      if (!response.ok) {
+        throw new Error(payload.error || "The removal report could not be submitted.");
+      }
+
+      setSubmitted(true);
+      setMessage(
+        payload.message || "Removal reported. An administrator will review it.",
+      );
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "The removal report could not be submitted.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.reportControl}>
+      <button
+        type="button"
+        className={styles.reportButton}
+        onClick={reportRemoved}
+        disabled={submitting || submitted}
+      >
+        {submitting
+          ? "Reporting…"
+          : submitted
+            ? "Removal reported"
+            : "Report gym as removed"}
+      </button>
+      {message && <small className={styles.success}>{message}</small>}
+      {error && <small className={styles.error}>{error}</small>}
+    </div>
+  );
+}

--- a/lib/gyms.ts
+++ b/lib/gyms.ts
@@ -17,11 +17,27 @@ export interface GymRecord {
   firstSeenAt: string | null;
 }
 
+export type GymRemovalReportStatus = "pending" | "approved" | "rejected";
+
+export interface GymRemovalReport {
+  id: string;
+  gymId: string;
+  gymName: string;
+  reportedById: string;
+  reportedByIgn: string | null;
+  reportedAt: string;
+  status: GymRemovalReportStatus;
+  reviewedAt: string | null;
+  reviewedById: string | null;
+  reviewedByIgn: string | null;
+}
+
 export interface GymState {
   version: 1;
   importedAt: string | null;
   sourceFile: string | null;
   gyms: GymRecord[];
+  removalReports: GymRemovalReport[];
 }
 
 export interface GymImportSummary {
@@ -39,6 +55,7 @@ const EMPTY_STATE: GymState = {
   importedAt: null,
   sourceFile: null,
   gyms: [],
+  removalReports: [],
 };
 
 function validGym(value: unknown): value is GymRecord {
@@ -62,6 +79,31 @@ function validGym(value: unknown): value is GymRecord {
     gym.lon >= -180 &&
     gym.lon <= 180
   );
+}
+
+function validRemovalReport(value: unknown): value is GymRemovalReport {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const report = value as Partial<GymRemovalReport>;
+
+  return (
+    typeof report.id === "string" &&
+    report.id.length > 0 &&
+    typeof report.gymId === "string" &&
+    report.gymId.length > 0 &&
+    typeof report.gymName === "string" &&
+    report.gymName.length > 0 &&
+    typeof report.reportedById === "string" &&
+    report.reportedById.length > 0 &&
+    typeof report.reportedAt === "string" &&
+    ["pending", "approved", "rejected"].includes(report.status || "")
+  );
+}
+
+function optionalText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 export async function readGymState(): Promise<GymState> {
@@ -91,6 +133,15 @@ export async function readGymState(): Promise<GymState> {
             ? gym.firstSeenAt
             : null,
       })),
+      removalReports: Array.isArray(parsed.removalReports)
+        ? parsed.removalReports.filter(validRemovalReport).map((report) => ({
+            ...report,
+            reportedByIgn: optionalText(report.reportedByIgn),
+            reviewedAt: optionalText(report.reviewedAt),
+            reviewedById: optionalText(report.reviewedById),
+            reviewedByIgn: optionalText(report.reviewedByIgn),
+          }))
+        : [],
     };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -136,6 +187,16 @@ export function getNewGymOpacity(gym: GymRecord, now = Date.now()): number {
 export function sortGyms(gyms: GymRecord[]): GymRecord[] {
   return [...gyms].sort((left, right) =>
     getGymDisplayName(left).localeCompare(getGymDisplayName(right), "en-GB"),
+  );
+}
+
+export function approvedRemovalGymIds(
+  reports: GymRemovalReport[],
+): Set<string> {
+  return new Set(
+    reports
+      .filter((report) => report.status === "approved")
+      .map((report) => report.gymId),
   );
 }
 

--- a/pages/admin/gym-removals.tsx
+++ b/pages/admin/gym-removals.tsx
@@ -1,0 +1,180 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import { useState } from "react";
+import {
+  readGymState,
+  type GymRemovalReport,
+} from "../../lib/gyms";
+import styles from "../../styles/GymRemovalAdmin.module.css";
+import { authOptions } from "../api/auth/[...nextauth]";
+
+interface GymRemovalAdminProps {
+  initialReports: GymRemovalReport[];
+}
+
+interface ReviewResponse {
+  error?: string;
+  message?: string;
+}
+
+export const getServerSideProps: GetServerSideProps<GymRemovalAdminProps> = async (
+  context,
+) => {
+  const session = await getServerSession(
+    context.req,
+    context.res,
+    authOptions as NextAuthOptions,
+  );
+
+  if ((session?.user as { role?: string } | undefined)?.role !== "admin") {
+    return {
+      redirect: { destination: "/login", permanent: false },
+    };
+  }
+
+  const state = await readGymState();
+
+  return {
+    props: {
+      initialReports: state.removalReports
+        .filter((report) => report.status === "pending")
+        .sort((left, right) => left.reportedAt.localeCompare(right.reportedAt)),
+    },
+  };
+};
+
+export default function GymRemovalAdminPage({
+  initialReports,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [reports, setReports] = useState(initialReports);
+  const [reviewingId, setReviewingId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function reviewReport(
+    report: GymRemovalReport,
+    decision: "approve" | "reject",
+  ) {
+    if (
+      decision === "approve" &&
+      !window.confirm(
+        `Approve removal of “${report.gymName}”? The gym will disappear from the map and remain suppressed during later CSV imports.`,
+      )
+    ) {
+      return;
+    }
+
+    setReviewingId(report.id);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/admin/gyms/removal-reports", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reportId: report.id, decision }),
+      });
+      const payload = (await response.json()) as ReviewResponse;
+
+      if (!response.ok) {
+        throw new Error(payload.error || "The removal report could not be reviewed.");
+      }
+
+      setReports((current) => current.filter((item) => item.id !== report.id));
+      setMessage(
+        payload.message ||
+          (decision === "approve"
+            ? "Removal approved."
+            : "Removal report rejected."),
+      );
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "The removal report could not be reviewed.",
+      );
+    } finally {
+      setReviewingId(null);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Gym Removal Reports | Leigh Pokémon Go Admin</title>
+      </Head>
+      <main className={`container ${styles.page}`}>
+        <header className={styles.header}>
+          <div>
+            <p className={styles.eyebrow}>Admin tools</p>
+            <h1>Gym removal reports</h1>
+            <p>
+              Review reports from members. A gym stays visible until you approve
+              its removal.
+            </p>
+          </div>
+          <div className={styles.links}>
+            <Link href="/gyms">Open gym map</Link>
+            <Link href="/admin/gyms">Gym data</Link>
+            <Link href="/admin">Back to admin</Link>
+          </div>
+        </header>
+
+        {message && <p className={styles.success}>{message}</p>}
+        {error && <p className={styles.error}>{error}</p>}
+
+        <section className={styles.card}>
+          <div className={styles.cardHeading}>
+            <div>
+              <h2>Pending review</h2>
+              <p>{reports.length} report{reports.length === 1 ? "" : "s"} waiting.</p>
+            </div>
+          </div>
+
+          {reports.length === 0 ? (
+            <p className={styles.empty}>There are no pending gym removal reports.</p>
+          ) : (
+            <div className={styles.reportList}>
+              {reports.map((report) => (
+                <article key={report.id} className={styles.report}>
+                  <div className={styles.reportDetails}>
+                    <strong>{report.gymName}</strong>
+                    <small>Gym ID: {report.gymId}</small>
+                    <small>
+                      Reported by {report.reportedByIgn || "a member"} on{" "}
+                      {new Date(report.reportedAt).toLocaleString("en-GB")}
+                    </small>
+                    <Link href={`/gyms?gym=${encodeURIComponent(report.gymId)}`}>
+                      View gym on map
+                    </Link>
+                  </div>
+                  <div className={styles.actions}>
+                    <button
+                      type="button"
+                      className={styles.approve}
+                      disabled={reviewingId === report.id}
+                      onClick={() => reviewReport(report, "approve")}
+                    >
+                      {reviewingId === report.id ? "Reviewing…" : "Approve removal"}
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.reject}
+                      disabled={reviewingId === report.id}
+                      onClick={() => reviewReport(report, "reject")}
+                    >
+                      Reject report
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+    </>
+  );
+}

--- a/pages/api/admin/gyms/removal-reports.ts
+++ b/pages/api/admin/gyms/removal-reports.ts
@@ -1,0 +1,113 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import {
+  readGymState,
+  writeGymState,
+  type GymRemovalReport,
+} from "../../../../lib/gyms";
+import { authOptions } from "../../auth/[...nextauth]";
+
+interface ReviewBody {
+  reportId?: unknown;
+  decision?: unknown;
+}
+
+type RemovalReportsResponse =
+  | { reports: GymRemovalReport[] }
+  | {
+      message: string;
+      report: GymRemovalReport;
+      gymRemoved: boolean;
+    }
+  | { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<RemovalReportsResponse>,
+) {
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+  const user = session?.user as {
+    id?: string | number;
+    ign?: string;
+    name?: string | null;
+    role?: string;
+  } | undefined;
+
+  if (user?.role !== "admin") {
+    return res.status(403).json({ error: "Access denied" });
+  }
+
+  if (req.method === "GET") {
+    const state = await readGymState();
+    const reports = state.removalReports
+      .filter((report) => report.status === "pending")
+      .sort((left, right) => left.reportedAt.localeCompare(right.reportedAt));
+
+    res.setHeader("Cache-Control", "private, no-store");
+    return res.status(200).json({ reports });
+  }
+
+  if (req.method !== "PATCH") {
+    res.setHeader("Allow", "GET, PATCH");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const body = req.body as ReviewBody;
+  const reportId = typeof body.reportId === "string" ? body.reportId.trim() : "";
+  const decision = body.decision === "approve" || body.decision === "reject"
+    ? body.decision
+    : null;
+
+  if (!reportId) {
+    return res.status(400).json({ error: "Removal report ID is required." });
+  }
+
+  if (!decision) {
+    return res.status(400).json({ error: "Choose approve or reject." });
+  }
+
+  const state = await readGymState();
+  const reportIndex = state.removalReports.findIndex(
+    (report) => report.id === reportId && report.status === "pending",
+  );
+
+  if (reportIndex < 0) {
+    return res.status(404).json({ error: "Pending removal report not found" });
+  }
+
+  const reviewedReport: GymRemovalReport = {
+    ...state.removalReports[reportIndex],
+    status: decision === "approve" ? "approved" : "rejected",
+    reviewedAt: new Date().toISOString(),
+    reviewedById: String(user.id ?? "unknown"),
+    reviewedByIgn:
+      typeof user.ign === "string" && user.ign.trim()
+        ? user.ign.trim()
+        : typeof user.name === "string" && user.name.trim()
+          ? user.name.trim()
+          : null,
+  };
+  const removalReports = [...state.removalReports];
+  removalReports[reportIndex] = reviewedReport;
+  const gymExisted = state.gyms.some((gym) => gym.id === reviewedReport.gymId);
+  const gyms = decision === "approve"
+    ? state.gyms.filter((gym) => gym.id !== reviewedReport.gymId)
+    : state.gyms;
+
+  await writeGymState({
+    ...state,
+    gyms,
+    removalReports,
+  });
+
+  res.setHeader("Cache-Control", "private, no-store");
+  return res.status(200).json({
+    message:
+      decision === "approve"
+        ? "Removal approved and the gym was removed from the map."
+        : "Removal report rejected; the gym remains on the map.",
+    report: reviewedReport,
+    gymRemoved: decision === "approve" && gymExisted,
+  });
+}

--- a/pages/api/admin/gyms/upload.ts
+++ b/pages/api/admin/gyms/upload.ts
@@ -6,6 +6,7 @@ import { getServerSession } from "next-auth/next";
 import { parse } from "csv-parse/sync";
 import { isCommunityGym } from "../../../../lib/communityGyms";
 import {
+  approvedRemovalGymIds,
   readGymState,
   writeGymState,
   type GymImportSummary,
@@ -243,8 +244,10 @@ export default async function handler(
 
   try {
     const buffer = decodeCsv(req.body as UploadBody);
-    const importedGyms = parseGyms(buffer);
+    const parsedGyms = parseGyms(buffer);
     const previous = await readGymState();
+    const suppressedGymIds = approvedRemovalGymIds(previous.removalReports);
+    const importedGyms = parsedGyms.filter((gym) => !suppressedGymIds.has(gym.id));
     const previousImportedGyms = previous.gyms.filter((gym) => !isCommunityGym(gym));
     const communityGyms = previous.gyms.filter(isCommunityGym);
     const previousById = new Map(previousImportedGyms.map((gym) => [gym.id, gym]));
@@ -282,7 +285,7 @@ export default async function handler(
 
     const importedIds = new Set(importedGymRecords.map((gym) => gym.id));
     const preservedCommunityGyms = communityGyms.filter(
-      (gym) => !importedIds.has(gym.id),
+      (gym) => !importedIds.has(gym.id) && !suppressedGymIds.has(gym.id),
     );
     const gyms = [...importedGymRecords, ...preservedCommunityGyms];
     const removed = previousImportedGyms.filter(
@@ -295,6 +298,7 @@ export default async function handler(
       importedAt,
       sourceFile,
       gyms,
+      removalReports: previous.removalReports,
     });
 
     const summary: GymImportSummary = {

--- a/pages/api/gyms/report-removed.ts
+++ b/pages/api/gyms/report-removed.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextAuthOptions } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import {
+  getGymDisplayName,
+  readGymState,
+  writeGymState,
+  type GymRemovalReport,
+} from "../../../lib/gyms";
+import { authOptions } from "../auth/[...nextauth]";
+
+interface ReportBody {
+  gymId?: unknown;
+}
+
+type ReportResponse =
+  | { message: string; report: GymRemovalReport }
+  | { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ReportResponse>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions as NextAuthOptions);
+
+  if (!session) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+
+  const gymId =
+    typeof (req.body as ReportBody).gymId === "string"
+      ? String((req.body as ReportBody).gymId).trim()
+      : "";
+
+  if (!gymId) {
+    return res.status(400).json({ error: "Gym ID is required." });
+  }
+
+  const state = await readGymState();
+  const gym = state.gyms.find((item) => item.id === gymId);
+
+  if (!gym) {
+    return res.status(404).json({ error: "Gym not found" });
+  }
+
+  const existing = state.removalReports.find(
+    (report) => report.gymId === gymId && report.status === "pending",
+  );
+
+  if (existing) {
+    res.setHeader("Cache-Control", "private, no-store");
+    return res.status(200).json({
+      message: "This gym is already awaiting administrator review.",
+      report: existing,
+    });
+  }
+
+  const user = session.user as {
+    id?: string | number;
+    ign?: string;
+    name?: string | null;
+  } | undefined;
+  const report: GymRemovalReport = {
+    id: randomUUID(),
+    gymId: gym.id,
+    gymName: getGymDisplayName(gym),
+    reportedById: String(user?.id ?? "unknown"),
+    reportedByIgn:
+      typeof user?.ign === "string" && user.ign.trim()
+        ? user.ign.trim()
+        : typeof user?.name === "string" && user.name.trim()
+          ? user.name.trim()
+          : null,
+    reportedAt: new Date().toISOString(),
+    status: "pending",
+    reviewedAt: null,
+    reviewedById: null,
+    reviewedByIgn: null,
+  };
+
+  await writeGymState({
+    ...state,
+    removalReports: [...state.removalReports, report],
+  });
+
+  res.setHeader("Cache-Control", "private, no-store");
+  return res.status(201).json({
+    message: "Gym removal reported. An administrator will review it.",
+    report,
+  });
+}

--- a/pages/gyms.tsx
+++ b/pages/gyms.tsx
@@ -4,6 +4,7 @@ import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import type { NextAuthOptions } from "next-auth";
 import { getServerSession } from "next-auth/next";
 import AddGymForm from "../components/gyms/AddGymForm";
+import GymRemovalReporter from "../components/gyms/GymRemovalReporter";
 import { readGymState, sortGyms } from "../lib/gyms";
 import { authOptions } from "./api/auth/[...nextauth]";
 
@@ -66,8 +67,8 @@ export default function GymsPage({
             <h1>Community gym map</h1>
             <p>
               Search official names and community aliases, find the nearest gyms,
-              add missing gyms from your current GPS location, and open turn-by-turn
-              directions in Google Maps.
+              add missing gyms, report removed gyms for admin review, and open
+              turn-by-turn directions in Google Maps.
             </p>
           </div>
           <div className="gym-legend" aria-label="Map legend">
@@ -77,6 +78,7 @@ export default function GymsPage({
           </div>
         </header>
         <AddGymForm />
+        <GymRemovalReporter gyms={gyms} />
         <GymMap gyms={gyms} importedAt={importedAt} />
       </main>
     </>

--- a/styles/GymRemovalAdmin.module.css
+++ b/styles/GymRemovalAdmin.module.css
@@ -1,0 +1,158 @@
+.page {
+  padding-top: 28px;
+  padding-bottom: 60px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+  margin-bottom: 22px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.header p:last-child {
+  color: #8b949e;
+  line-height: 1.55;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: #3fb950;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.links a,
+.reportDetails a {
+  color: #58a6ff;
+}
+
+.card {
+  padding: 22px;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  background: #161b22;
+}
+
+.cardHeading {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+
+.cardHeading h2 {
+  margin: 0 0 6px;
+}
+
+.cardHeading p,
+.empty {
+  margin: 0;
+  color: #8b949e;
+}
+
+.reportList {
+  display: grid;
+  gap: 12px;
+}
+
+.report {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  padding: 15px;
+  border: 1px solid #30363d;
+  border-radius: 9px;
+  background: #0d1117;
+}
+
+.reportDetails {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.reportDetails strong,
+.reportDetails small {
+  overflow-wrap: anywhere;
+}
+
+.reportDetails small {
+  color: #8b949e;
+}
+
+.actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.actions button {
+  border-radius: 7px;
+  padding: 9px 12px;
+  color: #fff;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.approve {
+  border: 0;
+  background: #da3633;
+}
+
+.reject {
+  border: 1px solid #30363d;
+  background: #21262d;
+}
+
+.success,
+.error {
+  padding: 11px 14px;
+  border-radius: 8px;
+}
+
+.success {
+  border: 1px solid #238636;
+  background: rgba(35, 134, 54, 0.15);
+}
+
+.error {
+  border: 1px solid #f85149;
+  background: rgba(248, 81, 73, 0.12);
+}
+
+@media (max-width: 760px) {
+  .header,
+  .report {
+    display: grid;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .actions button {
+    flex: 1 1 180px;
+  }
+}


### PR DESCRIPTION
## What changed

- Logged-in members can select a gym and submit a removal report.
- Reporting a gym does not immediately remove it; the marker remains until an administrator approves the report.
- Duplicate pending reports for the same gym are prevented.
- Administrators get a dedicated **Gym Removals** review page in the admin navigation.
- Admins can approve removal or reject the report.
- Approval atomically removes the gym and records an approved suppression in the existing gym state file.
- Approved removals remain suppressed during later CSV imports, preventing deleted gyms from reappearing.
- Added member and administrator API integration tests.

## Validation

- Full Jest suite passed.
- Production Next.js build passed on Node.js 20.
- GitHub Actions workflow completed successfully before merge.