### PR TITLE
Add role-aware homepage cards

### DIFF
--- a/__tests__/home-cards.test.js
+++ b/__tests__/home-cards.test.js
@@ -1,0 +1,34 @@
+const { getHomeCards } = require("../lib/homeCards");
+
+function cardTitles(options) {
+  return getHomeCards(options).map((card) => card.title);
+}
+
+describe("role-aware homepage cards", () => {
+  it("shows only friend codes and events to logged-out visitors", () => {
+    expect(cardTitles()).toEqual(["Friend Codes", "Events"]);
+  });
+
+  it("adds guides and the gym map for logged-in members", () => {
+    expect(cardTitles({ isLoggedIn: true })).toEqual([
+      "Friend Codes",
+      "Events",
+      "Guides",
+      "Gym Map",
+    ]);
+  });
+
+  it("adds the admin panel for administrators", () => {
+    expect(cardTitles({ isLoggedIn: true, isAdmin: true })).toEqual([
+      "Friend Codes",
+      "Events",
+      "Guides",
+      "Gym Map",
+      "Admin Panel",
+    ]);
+  });
+
+  it("treats an administrator as a logged-in member", () => {
+    expect(cardTitles({ isAdmin: true })).toContain("Gym Map");
+  });
+});

--- a/lib/homeCards.js
+++ b/lib/homeCards.js
@@ -1,0 +1,53 @@
+const PUBLIC_CARDS = [
+  {
+    href: "/friend-codes",
+    title: "Friend Codes",
+    description: "Browse community trainer codes and add your own after logging in.",
+    label: "Community",
+    tone: "friendCodes",
+  },
+  {
+    href: "/events",
+    title: "Events",
+    description: "See upcoming Pokémon GO events and local community activity.",
+    label: "Public",
+    tone: "events",
+  },
+];
+
+const MEMBER_CARDS = [
+  {
+    href: "/guides",
+    title: "Guides",
+    description: "Open community guides, tips and local information for players.",
+    label: "Members",
+    tone: "guides",
+  },
+  {
+    href: "/gyms",
+    title: "Gym Map",
+    description: "Find nearby gyms, get directions and help keep the map current.",
+    label: "Members",
+    tone: "gyms",
+  },
+];
+
+const ADMIN_CARDS = [
+  {
+    href: "/admin",
+    title: "Admin Panel",
+    description: "Manage users, content, events, gym data and community reports.",
+    label: "Admin",
+    tone: "admin",
+  },
+];
+
+export function getHomeCards({ isLoggedIn = false, isAdmin = false } = {}) {
+  const memberAccess = isLoggedIn || isAdmin;
+
+  return [
+    ...PUBLIC_CARDS,
+    ...(memberAccess ? MEMBER_CARDS : []),
+    ...(isAdmin ? ADMIN_CARDS : []),
+  ];
+}

--- a/pages/friend-codes.js
+++ b/pages/friend-codes.js
@@ -1,0 +1,267 @@
+import Head from "next/head"
+import { useSession } from "next-auth/react"
+import { useState } from "react"
+import prisma from "../lib/prisma"
+import TeamBadge from "../components/TeamBadge"
+
+async function copyTextToClipboard(value) {
+  if (navigator.clipboard?.writeText && window.isSecureContext) {
+    await navigator.clipboard.writeText(value)
+    return
+  }
+
+  const textArea = document.createElement("textarea")
+  textArea.value = value
+  textArea.setAttribute("readonly", "")
+  textArea.style.position = "fixed"
+  textArea.style.left = "-9999px"
+  textArea.style.opacity = "0"
+  document.body.appendChild(textArea)
+  textArea.select()
+  textArea.setSelectionRange(0, value.length)
+
+  const copied = document.execCommand("copy")
+  document.body.removeChild(textArea)
+
+  if (!copied) {
+    throw new Error("Clipboard copy failed")
+  }
+}
+
+export default function FriendCodes({ entries }) {
+  const { data: session } = useSession()
+  const [trainerName, setTrainerName] = useState("")
+  const [friendCode, setFriendCode] = useState("")
+  const [team, setTeam] = useState("MYSTIC")
+  const [message, setMessage] = useState("")
+  const [entryList, setEntryList] = useState(entries)
+  const [copiedEntryId, setCopiedEntryId] = useState(null)
+  const [copyError, setCopyError] = useState("")
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!session) {
+      setMessage("You must be logged in to add a friend code.")
+      return
+    }
+
+    const res = await fetch("/api/entries", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        trainerName,
+        friendCode,
+        team,
+      }),
+    })
+
+    if (res.ok) {
+      const newEntry = await res.json()
+      setEntryList((prev) => [newEntry, ...prev])
+      setTrainerName("")
+      setFriendCode("")
+      setTeam("MYSTIC")
+      setMessage("Entry added!")
+    } else {
+      const err = await res.json()
+      setMessage(err.error || "Failed to add entry.")
+    }
+  }
+
+  const handleCopyFriendCode = async (entry) => {
+    const code = String(entry.code || "").replace(/\D/g, "")
+
+    if (!code) {
+      setCopyError("This entry does not have a valid friend code to copy.")
+      return
+    }
+
+    try {
+      await copyTextToClipboard(code)
+      setCopiedEntryId(entry.id)
+      setCopyError("")
+    } catch (error) {
+      console.error("Failed to copy friend code", error)
+      setCopyError("The friend code could not be copied. Please copy it manually.")
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Friend Codes | Leigh Pokémon Go Community</title>
+        <meta
+          name="description"
+          content="Browse Pokémon GO friend codes from the Leigh community and add your own."
+        />
+      </Head>
+      <div className="container">
+        <div className="card">
+          <h1>Pokémon GO Friend Codes</h1>
+          <p className="muted">
+            Browse the latest codes from the community and add your own to let others
+            connect with you.
+          </p>
+        </div>
+
+        <div className="card">
+          <h2>Add your friend code</h2>
+          {session ? (
+            <form className="stack" onSubmit={handleSubmit}>
+              <div>
+                <label htmlFor="trainerName">Trainer Name</label>
+                <input
+                  id="trainerName"
+                  type="text"
+                  placeholder="Trainer Name"
+                  value={trainerName}
+                  onChange={(e) => setTrainerName(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="friendCode">Friend Code</label>
+                <input
+                  id="friendCode"
+                  type="text"
+                  placeholder="Friend Code"
+                  value={friendCode}
+                  onChange={(e) => setFriendCode(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="team">Team</label>
+                <select id="team" value={team} onChange={(e) => setTeam(e.target.value)}>
+                  <option value="INSTINCT">Instinct (Yellow)</option>
+                  <option value="MYSTIC">Mystic (Blue)</option>
+                  <option value="VALOR">Valor (Red)</option>
+                </select>
+              </div>
+              <button type="submit">Submit</button>
+            </form>
+          ) : (
+            <p className="muted">Log in to add your friend code.</p>
+          )}
+          {message && <p className="status">{message}</p>}
+        </div>
+
+        <div className="card">
+          <h2>Community friend codes</h2>
+          {entryList.length === 0 ? (
+            <p>No entries yet.</p>
+          ) : (
+            <ul className="entry-list">
+              {entryList.map((entry) => {
+                const hasCode = /\d/.test(String(entry.code || ""))
+                const copied = copiedEntryId === entry.id
+
+                return (
+                  <li key={entry.id} className="entry-row">
+                    <div className="entry-meta">
+                      <TeamBadge team={entry.team} />
+                      <strong>{entry.trainerName || entry.owner.ign}</strong>
+                    </div>
+                    <div className="entry-code-actions">
+                      <div className="entry-code">{entry.code || "No code provided"}</div>
+                      {hasCode && (
+                        <button
+                          type="button"
+                          className={`copy-code-button${copied ? " copied" : ""}`}
+                          onClick={() => handleCopyFriendCode(entry)}
+                          aria-label={`${copied ? "Copied" : "Copy"} ${entry.trainerName || entry.owner.ign}'s friend code`}
+                        >
+                          {copied ? "Copied" : "Copy"}
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+          {copyError && (
+            <p className="copy-error" role="alert">
+              {copyError}
+            </p>
+          )}
+        </div>
+
+        <style jsx>{`
+          .entry-code-actions {
+            display: flex;
+            min-width: 0;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 10px;
+          }
+
+          .copy-code-button {
+            width: auto;
+            min-width: 74px;
+            flex: 0 0 auto;
+            padding: 7px 10px;
+            border: 1px solid #30363d;
+            background: #21262d;
+          }
+
+          .copy-code-button:hover {
+            border-color: #58a6ff;
+            background: #30363d;
+          }
+
+          .copy-code-button.copied,
+          .copy-code-button.copied:hover {
+            border-color: #2ea043;
+            background: #238636;
+          }
+
+          .copy-error {
+            margin-top: 12px;
+            color: #ff7b72;
+          }
+
+          @media (max-width: 600px) {
+            .entry-row {
+              flex-direction: column;
+              align-items: stretch;
+              gap: 12px;
+            }
+
+            .entry-code-actions {
+              width: 100%;
+              justify-content: space-between;
+            }
+
+            .copy-code-button {
+              width: auto;
+            }
+          }
+        `}</style>
+      </div>
+    </>
+  )
+}
+
+export async function getServerSideProps() {
+  const entries = await prisma.entry.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      owner: {
+        select: {
+          ign: true,
+        },
+      },
+    },
+  })
+
+  const serializedEntries = entries.map((entry) => ({
+    ...entry,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  }))
+
+  return {
+    props: { entries: serializedEntries },
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,259 +1,69 @@
-import { useSession } from "next-auth/react"
-import { useState } from "react"
-import prisma from "../lib/prisma"
-import TeamBadge from "../components/TeamBadge"
+import Head from "next/head"
+import Link from "next/link"
+import { getServerSession } from "next-auth/next"
+import { getHomeCards } from "../lib/homeCards"
+import styles from "../styles/HomeDashboard.module.css"
+import { authOptions } from "./api/auth/[...nextauth]"
 
-async function copyTextToClipboard(value) {
-  if (navigator.clipboard?.writeText && window.isSecureContext) {
-    await navigator.clipboard.writeText(value)
-    return
-  }
-
-  const textArea = document.createElement("textarea")
-  textArea.value = value
-  textArea.setAttribute("readonly", "")
-  textArea.style.position = "fixed"
-  textArea.style.left = "-9999px"
-  textArea.style.opacity = "0"
-  document.body.appendChild(textArea)
-  textArea.select()
-  textArea.setSelectionRange(0, value.length)
-
-  const copied = document.execCommand("copy")
-  document.body.removeChild(textArea)
-
-  if (!copied) {
-    throw new Error("Clipboard copy failed")
-  }
-}
-
-export default function Home({ entries }) {
-  const { data: session } = useSession()
-  const [trainerName, setTrainerName] = useState("")
-  const [friendCode, setFriendCode] = useState("")
-  const [team, setTeam] = useState("MYSTIC")
-  const [message, setMessage] = useState("")
-  const [entryList, setEntryList] = useState(entries)
-  const [copiedEntryId, setCopiedEntryId] = useState(null)
-  const [copyError, setCopyError] = useState("")
-
-  const handleSubmit = async (e) => {
-    e.preventDefault()
-    if (!session) {
-      setMessage("You must be logged in to add a friend code.")
-      return
-    }
-
-    const res = await fetch("/api/entries", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        trainerName,
-        friendCode,
-        team,
-      }),
-    })
-
-    if (res.ok) {
-      const newEntry = await res.json()
-      setEntryList((prev) => [newEntry, ...prev])
-      setTrainerName("")
-      setFriendCode("")
-      setTeam("MYSTIC")
-      setMessage("Entry added!")
-    } else {
-      const err = await res.json()
-      setMessage(err.error || "Failed to add entry.")
-    }
-  }
-
-  const handleCopyFriendCode = async (entry) => {
-    const code = String(entry.code || "").replace(/\D/g, "")
-
-    if (!code) {
-      setCopyError("This entry does not have a valid friend code to copy.")
-      return
-    }
-
-    try {
-      await copyTextToClipboard(code)
-      setCopiedEntryId(entry.id)
-      setCopyError("")
-    } catch (error) {
-      console.error("Failed to copy friend code", error)
-      setCopyError("The friend code could not be copied. Please copy it manually.")
-    }
-  }
+export default function Home({ isLoggedIn, isAdmin }) {
+  const cards = getHomeCards({ isLoggedIn, isAdmin })
 
   return (
-    <div className="container">
-      <div className="card">
-        <h1>Pokémon GO Friend Codes</h1>
-        <p className="muted">
-          Browse the latest codes from the community and add your own to let others
-          connect with you.
-        </p>
-      </div>
+    <>
+      <Head>
+        <title>Leigh Pokémon Go Community</title>
+        <meta
+          name="description"
+          content="Friend codes, events, guides and community tools for Pokémon GO players around Leigh."
+        />
+      </Head>
 
-      <div className="card">
-        <h2>Add your friend code</h2>
-        {session ? (
-          <form className="stack" onSubmit={handleSubmit}>
-            <div>
-              <label htmlFor="trainerName">Trainer Name</label>
-              <input
-                id="trainerName"
-                type="text"
-                placeholder="Trainer Name"
-                value={trainerName}
-                onChange={(e) => setTrainerName(e.target.value)}
-                required
-              />
-            </div>
-            <div>
-              <label htmlFor="friendCode">Friend Code</label>
-              <input
-                id="friendCode"
-                type="text"
-                placeholder="Friend Code"
-                value={friendCode}
-                onChange={(e) => setFriendCode(e.target.value)}
-                required
-              />
-            </div>
-            <div>
-              <label htmlFor="team">Team</label>
-              <select id="team" value={team} onChange={(e) => setTeam(e.target.value)}>
-                <option value="INSTINCT">Instinct (Yellow)</option>
-                <option value="MYSTIC">Mystic (Blue)</option>
-                <option value="VALOR">Valor (Red)</option>
-              </select>
-            </div>
-            <button type="submit">Submit</button>
-          </form>
-        ) : (
-          <p className="muted">Log in to add your friend code.</p>
-        )}
-        {message && <p className="status">{message}</p>}
-      </div>
+      <main className={`container ${styles.page}`}>
+        <header className={styles.hero}>
+          <p className={styles.eyebrow}>Leigh Pokémon GO Community</p>
+          <h1>Community hub</h1>
+          <p className={styles.intro}>
+            Open the tools and information available to your account from one place.
+          </p>
+        </header>
 
-      <div className="card">
-        <h2>Community friend codes</h2>
-        {entryList.length === 0 ? (
-          <p>No entries yet.</p>
-        ) : (
-          <ul className="entry-list">
-            {entryList.map((entry) => {
-              const hasCode = /\d/.test(String(entry.code || ""))
-              const copied = copiedEntryId === entry.id
+        <section className={styles.grid} aria-label="Community sections">
+          {cards.map((card) => (
+            <Link
+              key={card.href}
+              href={card.href}
+              className={`${styles.card} ${styles[card.tone]}`}
+            >
+              <div>
+                <div className={styles.cardHeader}>
+                  <span className={styles.label}>{card.label}</span>
+                </div>
+                <h2>{card.title}</h2>
+                <p>{card.description}</p>
+              </div>
+              <span className={styles.open}>Open section <span aria-hidden="true">→</span></span>
+            </Link>
+          ))}
+        </section>
 
-              return (
-                <li key={entry.id} className="entry-row">
-                  <div className="entry-meta">
-                    <TeamBadge team={entry.team} />
-                    <strong>{entry.trainerName || entry.owner.ign}</strong>
-                  </div>
-                  <div className="entry-code-actions">
-                    <div className="entry-code">{entry.code || "No code provided"}</div>
-                    {hasCode && (
-                      <button
-                        type="button"
-                        className={`copy-code-button${copied ? " copied" : ""}`}
-                        onClick={() => handleCopyFriendCode(entry)}
-                        aria-label={`${copied ? "Copied" : "Copy"} ${entry.trainerName || entry.owner.ign}'s friend code`}
-                      >
-                        {copied ? "Copied" : "Copy"}
-                      </button>
-                    )}
-                  </div>
-                </li>
-              )
-            })}
-          </ul>
-        )}
-        {copyError && (
-          <p className="copy-error" role="alert">
-            {copyError}
+        {!isLoggedIn && (
+          <p className={styles.loginNote}>
+            <Link href="/login">Log in</Link> to unlock community guides and the private gym map.
           </p>
         )}
-      </div>
-
-      <style jsx>{`
-        .entry-code-actions {
-          display: flex;
-          min-width: 0;
-          align-items: center;
-          justify-content: flex-end;
-          gap: 10px;
-        }
-
-        .copy-code-button {
-          width: auto;
-          min-width: 74px;
-          flex: 0 0 auto;
-          padding: 7px 10px;
-          border: 1px solid #30363d;
-          background: #21262d;
-        }
-
-        .copy-code-button:hover {
-          border-color: #58a6ff;
-          background: #30363d;
-        }
-
-        .copy-code-button.copied,
-        .copy-code-button.copied:hover {
-          border-color: #2ea043;
-          background: #238636;
-        }
-
-        .copy-error {
-          margin-top: 12px;
-          color: #ff7b72;
-        }
-
-        @media (max-width: 600px) {
-          .entry-row {
-            flex-direction: column;
-            align-items: stretch;
-            gap: 12px;
-          }
-
-          .entry-code-actions {
-            width: 100%;
-            justify-content: space-between;
-          }
-
-          .copy-code-button {
-            width: auto;
-          }
-        }
-      `}</style>
-    </div>
+      </main>
+    </>
   )
 }
 
-// Fetch all entries for server-side rendering
-export async function getServerSideProps() {
-  const entries = await prisma.entry.findMany({
-    orderBy: { createdAt: "desc" },
-    include: {
-      owner: {
-        select: {
-          ign: true,
-        },
-      },
-    },
-  })
-
-  // Serialize dates to strings for JSON
-  const serializedEntries = entries.map(entry => ({
-    ...entry,
-    createdAt: entry.createdAt.toISOString(),
-    updatedAt: entry.updatedAt.toISOString(),
-  }))
+export async function getServerSideProps(context) {
+  const session = await getServerSession(context.req, context.res, authOptions)
+  const role = session?.user?.role
 
   return {
-    props: { entries: serializedEntries },
+    props: {
+      isLoggedIn: Boolean(session),
+      isAdmin: role === "admin",
+    },
   }
 }

--- a/styles/HomeDashboard.module.css
+++ b/styles/HomeDashboard.module.css
@@ -1,0 +1,174 @@
+.page {
+  padding-top: 38px;
+  padding-bottom: 64px;
+}
+
+.hero {
+  margin-bottom: 26px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #3fb950;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 7vw, 4.6rem);
+  line-height: 1;
+}
+
+.intro {
+  max-width: 680px;
+  margin: 14px 0 0;
+  color: #8b949e;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.card {
+  display: flex;
+  min-height: 210px;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  border: 1px solid #30363d;
+  border-radius: 14px;
+  padding: 22px;
+  background: #161b22;
+  color: #f0f6fc;
+  text-decoration: none;
+  transition:
+    transform 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-3px);
+  border-color: #58a6ff;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.22);
+  outline: none;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.label {
+  border: 1px solid #30363d;
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: #8b949e;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.card h2 {
+  margin: 22px 0 8px;
+  font-size: 1.65rem;
+}
+
+.card p {
+  margin: 0;
+  color: #b1bac4;
+  line-height: 1.55;
+}
+
+.open {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 24px;
+  color: #79c0ff;
+  font-weight: 800;
+}
+
+.friendCodes {
+  background:
+    radial-gradient(circle at top right, rgba(163, 113, 247, 0.22), transparent 42%),
+    #161b22;
+}
+
+.events {
+  background:
+    radial-gradient(circle at top right, rgba(46, 160, 67, 0.22), transparent 42%),
+    #161b22;
+}
+
+.guides {
+  background:
+    radial-gradient(circle at top right, rgba(56, 139, 253, 0.22), transparent 42%),
+    #161b22;
+}
+
+.gyms {
+  background:
+    radial-gradient(circle at top right, rgba(242, 204, 96, 0.2), transparent 42%),
+    #161b22;
+}
+
+.admin {
+  grid-column: 1 / -1;
+  min-height: 180px;
+  border-color: #6e5500;
+  background:
+    radial-gradient(circle at top right, rgba(242, 204, 96, 0.2), transparent 36%),
+    linear-gradient(135deg, #1f1b0d, #161b22 68%);
+}
+
+.admin .label {
+  border-color: #6e5500;
+  color: #f2cc60;
+}
+
+.loginNote {
+  margin: 20px 0 0;
+  color: #8b949e;
+  text-align: center;
+}
+
+.loginNote a {
+  color: #79c0ff;
+  font-weight: 700;
+}
+
+@media (max-width: 700px) {
+  .page {
+    padding-top: 24px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin {
+    grid-column: auto;
+  }
+
+  .card {
+    min-height: 185px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What changed

- Replaces the existing first page with a responsive card dashboard.
- Logged-out visitors see **Friend Codes** and **Events**.
- Logged-in members also see **Guides** and **Gym Map**.
- Administrators additionally see **Admin Panel**.
- Moves the complete existing friend-code page to `/friend-codes` without removing its browsing, submission or copy functionality.
- Uses the server-side session to prevent logged-out visitors briefly seeing member/admin cards during page load.
- Adds unit tests covering guest, member and administrator card visibility.

## Validation

- Full Jest suite passed.
- Production Next.js build passed on Node.js 20.
- GitHub Actions completed successfully before merge.