### PR TITLE
Filter Pokédex to released Pokémon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .env
 .DS_Store
 .nextauth-secret
+/data/.cache/
 /data/events-cache.json*
 /data/local-events.json*
 /data/event-overrides.json*

--- a/__tests__/lib/releasedPokemonCache.test.js
+++ b/__tests__/lib/releasedPokemonCache.test.js
@@ -1,0 +1,53 @@
+const {
+  CACHE_TTL_MS,
+  extractReleasedDexNumbers,
+  filterReleasedDexNumbers,
+  isCacheFresh,
+  normaliseDexNumbers,
+} = require("../../lib/releasedPokemonCache");
+
+describe("released Pokémon cache helpers", () => {
+  it("extracts sorted unique dex numbers from PogoAPI data", () => {
+    const payload = Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => {
+        const id = index + 1;
+        return [String(id), { id, name: `Pokemon ${id}` }];
+      })
+    );
+
+    payload["101"] = { id: 25, name: "Duplicate Pikachu" };
+
+    const dexNumbers = extractReleasedDexNumbers(payload);
+
+    expect(dexNumbers).toHaveLength(100);
+    expect(dexNumbers[0]).toBe(1);
+    expect(dexNumbers.at(-1)).toBe(100);
+  });
+
+  it("rejects an unexpectedly small release payload", () => {
+    expect(() =>
+      extractReleasedDexNumbers({
+        1: { id: 1, name: "Bulbasaur" },
+      })
+    ).toThrow("unexpectedly small");
+  });
+
+  it("normalises and filters saved values to released dex numbers", () => {
+    expect(normaliseDexNumbers([3, "2", 2, 0, -1, "bad", 1])).toEqual([1, 2, 3]);
+    expect(filterReleasedDexNumbers([1, 2, 3, 999], [1, 3, 4])).toEqual([1, 3]);
+  });
+
+  it("treats the cache as fresh for seven days", () => {
+    const now = Date.parse("2026-07-31T12:00:00.000Z");
+    const cache = { checkedAt: new Date(now - CACHE_TTL_MS + 1_000).toISOString() };
+
+    expect(isCacheFresh(cache, CACHE_TTL_MS, now)).toBe(true);
+    expect(
+      isCacheFresh(
+        { checkedAt: new Date(now - CACHE_TTL_MS - 1_000).toISOString() },
+        CACHE_TTL_MS,
+        now
+      )
+    ).toBe(false);
+  });
+});

--- a/data/pogoapi/released-pokemon.json
+++ b/data/pogoapi/released-pokemon.json
@@ -1,0 +1,5 @@
+{
+  "checkedAt": null,
+  "sourceHash": null,
+  "dexNumbers": []
+}

--- a/lib/releasedPokemonCache.js
+++ b/lib/releasedPokemonCache.js
@@ -1,0 +1,238 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+const RELEASED_POKEMON_URL = "https://pogoapi.net/api/v1/released_pokemon.json";
+const API_HASHES_URL = "https://pogoapi.net/api/v1/api_hashes.json";
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const MIN_EXPECTED_RELEASED_POKEMON = 100;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+let refreshPromise = null;
+
+const runtimeCachePath = () =>
+  process.env.POGOAPI_RELEASED_CACHE_PATH ||
+  path.join(process.cwd(), "data", ".cache", "released-pokemon.json");
+
+const bootstrapCachePath = () =>
+  process.env.POGOAPI_RELEASED_BOOTSTRAP_PATH ||
+  path.join(process.cwd(), "data", "pogoapi", "released-pokemon.json");
+
+function normaliseDexNumbers(values) {
+  if (!Array.isArray(values)) return [];
+
+  return Array.from(
+    new Set(
+      values
+        .map((value) => Number(value))
+        .filter((value) => Number.isInteger(value) && value > 0)
+    )
+  ).sort((a, b) => a - b);
+}
+
+function extractReleasedDexNumbers(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("PogoAPI returned an invalid released Pokémon payload.");
+  }
+
+  const dexNumbers = normaliseDexNumbers(
+    Object.entries(payload).map(([key, pokemon]) => pokemon?.id ?? key)
+  );
+
+  if (dexNumbers.length < MIN_EXPECTED_RELEASED_POKEMON) {
+    throw new Error("PogoAPI released Pokémon payload was unexpectedly small.");
+  }
+
+  return dexNumbers;
+}
+
+function validateCache(cache) {
+  if (!cache || typeof cache !== "object") return null;
+
+  const dexNumbers = normaliseDexNumbers(cache.dexNumbers);
+  if (dexNumbers.length < MIN_EXPECTED_RELEASED_POKEMON) return null;
+
+  const checkedAt = new Date(cache.checkedAt).toISOString();
+
+  return {
+    checkedAt,
+    sourceHash: typeof cache.sourceHash === "string" ? cache.sourceHash : null,
+    dexNumbers,
+  };
+}
+
+function isCacheFresh(cache, maxAgeMs = CACHE_TTL_MS, now = Date.now()) {
+  if (!cache?.checkedAt) return false;
+  const checkedAt = Date.parse(cache.checkedAt);
+  return Number.isFinite(checkedAt) && now - checkedAt < maxAgeMs;
+}
+
+function filterReleasedDexNumbers(values, releasedDexNumbers) {
+  const releasedSet = new Set(normaliseDexNumbers(releasedDexNumbers));
+  return normaliseDexNumbers(values).filter((dexNumber) => releasedSet.has(dexNumber));
+}
+
+async function readJson(filePath) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT" || error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
+async function readCache(filePath) {
+  const rawCache = await readJson(filePath);
+  try {
+    return validateCache(rawCache);
+  } catch {
+    return null;
+  }
+}
+
+async function readBestCache(targetPath, includeBootstrap) {
+  const targetCache = await readCache(targetPath);
+  if (targetCache) return targetCache;
+
+  if (includeBootstrap && targetPath !== bootstrapCachePath()) {
+    return readCache(bootstrapCachePath());
+  }
+
+  return null;
+}
+
+async function fetchJson(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "LEIGHPOGO released-pokemon-cache",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`PogoAPI request failed with status ${response.status}.`);
+    }
+
+    return response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchReleasedPokemonHash() {
+  const hashes = await fetchJson(API_HASHES_URL);
+  const releasedHash = hashes?.["released_pokemon.json"];
+
+  return (
+    releasedHash?.hash_sha256 ||
+    releasedHash?.hash_sha1 ||
+    releasedHash?.hash_md5 ||
+    null
+  );
+}
+
+async function writeCache(filePath, cache, strictWrite) {
+  const directory = path.dirname(filePath);
+  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+
+  try {
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(temporaryPath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+    await fs.rename(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      await fs.unlink(temporaryPath);
+    } catch {}
+
+    if (strictWrite) throw error;
+    console.error("Unable to persist the released Pokémon cache", error);
+  }
+}
+
+async function refreshReleasedPokemonData(existingCache, options) {
+  const checkedAt = new Date().toISOString();
+  let sourceHash = null;
+
+  try {
+    sourceHash = await fetchReleasedPokemonHash();
+  } catch (error) {
+    console.warn("Unable to check the PogoAPI release-list hash; downloading the list directly", error);
+  }
+
+  if (
+    sourceHash &&
+    existingCache?.sourceHash === sourceHash &&
+    existingCache.dexNumbers.length >= MIN_EXPECTED_RELEASED_POKEMON
+  ) {
+    const unchangedCache = options.touchWhenUnchanged
+      ? { ...existingCache, checkedAt }
+      : existingCache;
+
+    if (options.touchWhenUnchanged) {
+      await writeCache(options.cachePath, unchangedCache, options.strictWrite);
+    }
+
+    return unchangedCache;
+  }
+
+  const releasedPokemon = await fetchJson(RELEASED_POKEMON_URL);
+  const refreshedCache = {
+    checkedAt,
+    sourceHash,
+    dexNumbers: extractReleasedDexNumbers(releasedPokemon),
+  };
+
+  await writeCache(options.cachePath, refreshedCache, options.strictWrite);
+  return refreshedCache;
+}
+
+async function getReleasedPokemonData(options = {}) {
+  const resolvedOptions = {
+    allowStale: options.allowStale !== false,
+    cachePath: options.cachePath || runtimeCachePath(),
+    forceRefresh: options.forceRefresh === true,
+    includeBootstrap: options.includeBootstrap !== false,
+    strictWrite: options.strictWrite === true,
+    touchWhenUnchanged: options.touchWhenUnchanged !== false,
+  };
+
+  const existingCache = await readBestCache(
+    resolvedOptions.cachePath,
+    resolvedOptions.includeBootstrap
+  );
+
+  if (!resolvedOptions.forceRefresh && isCacheFresh(existingCache)) {
+    return { ...existingCache, stale: false };
+  }
+
+  if (!refreshPromise) {
+    refreshPromise = refreshReleasedPokemonData(existingCache, resolvedOptions).finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  try {
+    const refreshedCache = await refreshPromise;
+    return { ...refreshedCache, stale: false };
+  } catch (error) {
+    if (resolvedOptions.allowStale && existingCache) {
+      console.error("Unable to refresh released Pokémon; using the last valid cache", error);
+      return { ...existingCache, stale: true };
+    }
+
+    throw error;
+  }
+}
+
+module.exports = {
+  CACHE_TTL_MS,
+  extractReleasedDexNumbers,
+  filterReleasedDexNumbers,
+  getReleasedPokemonData,
+  isCacheFresh,
+  normaliseDexNumbers,
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "postinstall": "prisma generate",
     "db:status": "prisma migrate status",
-    "db:deploy": "prisma migrate deploy"
+    "db:deploy": "prisma migrate deploy",
+    "pogoapi:update": "node scripts/updateReleasedPokemonCache.js"
   },
   "dependencies": {
     "@prisma/client": "^5.8.0",

--- a/pages/api/pokedex.js
+++ b/pages/api/pokedex.js
@@ -2,6 +2,11 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "./auth/[...nextauth]"
 import prisma from "../../lib/prisma"
 
+const {
+  filterReleasedDexNumbers,
+  getReleasedPokemonData,
+} = require("../../lib/releasedPokemonCache")
+
 async function ensureSession(req, res) {
   const session = await getServerSession(req, res, authOptions)
   if (!session) {
@@ -11,9 +16,22 @@ async function ensureSession(req, res) {
   return session
 }
 
+async function loadReleasedPokemon(res) {
+  try {
+    return await getReleasedPokemonData()
+  } catch (error) {
+    console.error("Failed to load released Pokémon data", error)
+    res.status(503).json({ error: "The released Pokémon list is temporarily unavailable." })
+    return null
+  }
+}
+
 export default async function handler(req, res) {
   const session = await ensureSession(req, res)
   if (!session) return
+
+  const releasedPokemonData = await loadReleasedPokemon(res)
+  if (!releasedPokemonData) return
 
   if (req.method === "GET") {
     try {
@@ -22,7 +40,12 @@ export default async function handler(req, res) {
         select: { dexNumber: true },
       })
 
-      res.status(200).json({ dexNumbers: entries.map((entry) => entry.dexNumber) })
+      res.status(200).json({
+        dexNumbers: filterReleasedDexNumbers(
+          entries.map((entry) => entry.dexNumber),
+          releasedPokemonData.dexNumbers
+        ),
+      })
     } catch (error) {
       console.error("Failed to fetch Pokédex entries", error)
       res.status(500).json({ error: "Unable to load your Pokédex right now." })
@@ -38,23 +61,22 @@ export default async function handler(req, res) {
       return
     }
 
-    const uniqueDexNumbers = Array.from(
-      new Set(
-        dexNumbers
-          .map((value) => Number(value))
-          .filter((value) => Number.isInteger(value) && value > 0)
-      )
+    const releasedDexNumbers = filterReleasedDexNumbers(
+      dexNumbers,
+      releasedPokemonData.dexNumbers
     )
 
     try {
       await prisma.$transaction([
         prisma.pokedexEntry.deleteMany({
-          where: {
-            ownerId: session.user.id,
-            dexNumber: { notIn: uniqueDexNumbers },
-          },
+          where: releasedDexNumbers.length
+            ? {
+                ownerId: session.user.id,
+                dexNumber: { notIn: releasedDexNumbers },
+              }
+            : { ownerId: session.user.id },
         }),
-        ...uniqueDexNumbers.map((dexNumber) =>
+        ...releasedDexNumbers.map((dexNumber) =>
           prisma.pokedexEntry.upsert({
             where: {
               ownerId_dexNumber: { ownerId: session.user.id, dexNumber },
@@ -65,7 +87,7 @@ export default async function handler(req, res) {
         ),
       ])
 
-      res.status(200).json({ dexNumbers: uniqueDexNumbers })
+      res.status(200).json({ dexNumbers: releasedDexNumbers })
     } catch (error) {
       console.error("Failed to save Pokédex entries", error)
       res.status(500).json({ error: "Unable to save your Pokédex right now." })

--- a/pages/pokedex.js
+++ b/pages/pokedex.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { useSession } from "next-auth/react"
-import pokedexByRegion, { flatPokemonList } from "../lib/pokedexData"
+import pokedexByRegion from "../lib/pokedexData"
 
 const buildSpriteUrl = ({ dexNumber }) =>
   `https://raw.githubusercontent.com/nileplumb/PkmnHomeIcons/master/UICONS_OS/pokemon/${dexNumber.toString()}.png`
@@ -65,13 +65,38 @@ function PokedexRegion({ region, caughtSet, onToggle }) {
   )
 }
 
-export default function PokedexPage() {
+export default function PokedexPage({
+  releasedDexNumbers = [],
+  releaseDataStale = false,
+  releaseDataError = "",
+}) {
   const { data: session, status } = useSession()
   const [caughtSet, setCaughtSet] = useState(new Set())
   const [statusMessage, setStatusMessage] = useState("")
   const [isSaving, setIsSaving] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [lastSaved, setLastSaved] = useState(null)
+
+  const releasedSet = useMemo(
+    () => new Set(releasedDexNumbers.map((dexNumber) => Number(dexNumber))),
+    [releasedDexNumbers]
+  )
+
+  const availablePokedex = useMemo(
+    () =>
+      pokedexByRegion
+        .map((region) => ({
+          ...region,
+          pokemon: region.pokemon.filter((pokemon) => releasedSet.has(pokemon.dexNumber)),
+        }))
+        .filter((region) => region.pokemon.length > 0),
+    [releasedSet]
+  )
+
+  const availablePokemonList = useMemo(
+    () => availablePokedex.flatMap((region) => region.pokemon),
+    [availablePokedex]
+  )
 
   useEffect(() => {
     if (status !== "authenticated") return
@@ -82,7 +107,9 @@ export default function PokedexPage() {
         const response = await fetch("/api/pokedex")
         if (!response.ok) throw new Error("Unable to load your Pokédex")
         const data = await response.json()
-        setCaughtSet(new Set(data.dexNumbers))
+        setCaughtSet(
+          new Set(data.dexNumbers.filter((dexNumber) => releasedSet.has(Number(dexNumber))))
+        )
       } catch (error) {
         setStatusMessage(error.message)
       } finally {
@@ -91,9 +118,11 @@ export default function PokedexPage() {
     }
 
     fetchData()
-  }, [status])
+  }, [releasedSet, status])
 
   const toggleCaught = (dexNumber) => {
+    if (!releasedSet.has(dexNumber)) return
+
     setCaughtSet((prev) => {
       const next = new Set(prev)
       if (next.has(dexNumber)) {
@@ -105,17 +134,25 @@ export default function PokedexPage() {
     })
   }
 
-  const caughtCount = caughtSet.size
-  const caughtPercentage = Math.round((caughtCount / flatPokemonList.length) * 100)
+  const caughtCount = useMemo(
+    () => Array.from(caughtSet).filter((dexNumber) => releasedSet.has(dexNumber)).length,
+    [caughtSet, releasedSet]
+  )
+  const caughtPercentage = availablePokemonList.length
+    ? Math.round((caughtCount / availablePokemonList.length) * 100)
+    : 0
 
   const handleSave = async () => {
     setIsSaving(true)
     setStatusMessage("")
     try {
+      const releasedCaughtDexNumbers = Array.from(caughtSet).filter((dexNumber) =>
+        releasedSet.has(dexNumber)
+      )
       const response = await fetch("/api/pokedex", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dexNumbers: Array.from(caughtSet) }),
+        body: JSON.stringify({ dexNumbers: releasedCaughtDexNumbers }),
       })
 
       if (!response.ok) throw new Error("Failed to save your Pokédex.")
@@ -145,6 +182,19 @@ export default function PokedexPage() {
     )
   }
 
+  if (!availablePokemonList.length) {
+    return (
+      <div className="container">
+        <div className="card">
+          <h1>Pokédex Tracker</h1>
+          <p className="status-text">
+            {releaseDataError || "The released Pokémon list is temporarily unavailable."}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="container">
       <div className="card pokedex-hero">
@@ -152,8 +202,11 @@ export default function PokedexPage() {
           <h1>Pokédex Tracker</h1>
           <p className="muted">Mark Pokémon you’ve obtained by National Dex order, grouped by region.</p>
           <p className="muted">
-            Progress: {caughtCount} / {flatPokemonList.length} ({caughtPercentage}%)
+            Progress: {caughtCount} / {availablePokemonList.length} ({caughtPercentage}%)
           </p>
+          {releaseDataStale && (
+            <p className="muted">Using the last cached release list while PogoAPI is unavailable.</p>
+          )}
           {lastSaved && (
             <p className="muted">Last saved: {lastSaved.toLocaleString()}</p>
           )}
@@ -168,7 +221,7 @@ export default function PokedexPage() {
 
       {isLoading && <p className="muted">Loading your saved Pokédex…</p>}
 
-      {pokedexByRegion.map((region) => (
+      {availablePokedex.map((region) => (
         <PokedexRegion
           key={region.region}
           region={region}
@@ -178,4 +231,29 @@ export default function PokedexPage() {
       ))}
     </div>
   )
+}
+
+export async function getServerSideProps() {
+  try {
+    const { getReleasedPokemonData } = require("../lib/releasedPokemonCache")
+    const releasedPokemonData = await getReleasedPokemonData()
+
+    return {
+      props: {
+        releasedDexNumbers: releasedPokemonData.dexNumbers,
+        releaseDataStale: releasedPokemonData.stale,
+        releaseDataError: "",
+      },
+    }
+  } catch (error) {
+    console.error("Unable to load the released Pokémon list", error)
+
+    return {
+      props: {
+        releasedDexNumbers: [],
+        releaseDataStale: false,
+        releaseDataError: "The released Pokémon list could not be loaded. Please try again shortly.",
+      },
+    }
+  }
 }

--- a/scripts/updateReleasedPokemonCache.js
+++ b/scripts/updateReleasedPokemonCache.js
@@ -1,0 +1,24 @@
+const path = require("path");
+const { getReleasedPokemonData } = require("../lib/releasedPokemonCache");
+
+const cachePath =
+  process.env.POGOAPI_RELEASED_CACHE_PATH ||
+  path.join(process.cwd(), "data", "pogoapi", "released-pokemon.json");
+
+getReleasedPokemonData({
+  allowStale: false,
+  cachePath,
+  forceRefresh: true,
+  includeBootstrap: false,
+  strictWrite: true,
+  touchWhenUnchanged: false,
+})
+  .then((cache) => {
+    console.log(
+      `Released Pokémon cache contains ${cache.dexNumbers.length} entries (${cache.sourceHash || "no source hash"}).`
+    );
+  })
+  .catch((error) => {
+    console.error("Failed to update the released Pokémon cache", error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## What changed

- Uses PogoAPI's `released_pokemon.json` as the allow-list for the Pokédex tracker.
- Filters every region so unreleased Pokémon are not displayed.
- Calculates caught totals and percentages only from Pokémon currently available in Pokémon GO.
- Filters loaded and saved user entries against the same released-ID list.
- Removes hidden/unreleased saved entries the next time a user saves their Pokédex.
- Adds a seven-day server-side cache with atomic writes and a stale-cache fallback when PogoAPI is unavailable.
- Checks PogoAPI's hash endpoint before downloading the full release list again.
- Adds a manual `npm run pogoapi:update` refresh command and focused cache/filter tests.

## Behaviour

The first request after deployment populates the runtime cache. After seven days, the next Pokédex request checks the upstream hash and refreshes only when needed. A valid older cache remains usable during an upstream outage.

## Validation

Repository CI should run lint, Jest and the production build on this pull request.