### PR TITLE
Add trade listings card to homepage

### DIFF
--- a/__tests__/home-cards.test.js
+++ b/__tests__/home-cards.test.js
@@ -1,22 +1,41 @@
-const { getHomeCards } = require("../lib/homeCards");
+const { getHomeCards } = require("../lib/homeCards")
 
 function cardTitles(options) {
-  return getHomeCards(options).map((card) => card.title);
+  return getHomeCards(options).map((card) => card.title)
+}
+
+function tradeCard(options) {
+  return getHomeCards(options).find((card) => card.title === "Trade Listings")
 }
 
 describe("role-aware homepage cards", () => {
   it("shows only friend codes and events to logged-out visitors", () => {
-    expect(cardTitles()).toEqual(["Friend Codes", "Events"]);
-  });
+    expect(cardTitles()).toEqual(["Friend Codes", "Events"])
+  })
 
-  it("adds guides and the gym map for logged-in members", () => {
+  it("adds member tools and trade listings for logged-in members", () => {
     expect(cardTitles({ isLoggedIn: true })).toEqual([
       "Friend Codes",
       "Events",
       "Guides",
       "Gym Map",
-    ]);
-  });
+      "Trade Listings",
+    ])
+  })
+
+  it("sends members without a friend code to the friend-code page", () => {
+    expect(tradeCard({ isLoggedIn: true })).toMatchObject({
+      href: "/friend-codes",
+      title: "Trade Listings",
+    })
+  })
+
+  it("sends eligible members to the private trade listings", () => {
+    expect(tradeCard({ isLoggedIn: true, hasFriendCode: true })).toMatchObject({
+      href: "/trades",
+      title: "Trade Listings",
+    })
+  })
 
   it("adds the admin panel for administrators", () => {
     expect(cardTitles({ isLoggedIn: true, isAdmin: true })).toEqual([
@@ -24,11 +43,12 @@ describe("role-aware homepage cards", () => {
       "Events",
       "Guides",
       "Gym Map",
+      "Trade Listings",
       "Admin Panel",
-    ]);
-  });
+    ])
+  })
 
   it("treats an administrator as a logged-in member", () => {
-    expect(cardTitles({ isAdmin: true })).toContain("Gym Map");
-  });
-});
+    expect(cardTitles({ isAdmin: true })).toContain("Trade Listings")
+  })
+})

--- a/lib/homeCards.js
+++ b/lib/homeCards.js
@@ -13,7 +13,7 @@ const PUBLIC_CARDS = [
     label: "Public",
     tone: "events",
   },
-];
+]
 
 const MEMBER_CARDS = [
   {
@@ -30,7 +30,17 @@ const MEMBER_CARDS = [
     label: "Members",
     tone: "gyms",
   },
-];
+]
+
+const getTradeCard = (hasFriendCode) => ({
+  href: hasFriendCode ? "/trades" : "/friend-codes",
+  title: "Trade Listings",
+  description: hasFriendCode
+    ? "Browse private Pokémon trade offers from registered community members."
+    : "Add your Pokémon GO friend code to unlock private trade listings.",
+  label: "Members",
+  tone: "trades",
+})
 
 const ADMIN_CARDS = [
   {
@@ -40,14 +50,18 @@ const ADMIN_CARDS = [
     label: "Admin",
     tone: "admin",
   },
-];
+]
 
-export function getHomeCards({ isLoggedIn = false, isAdmin = false } = {}) {
-  const memberAccess = isLoggedIn || isAdmin;
+export function getHomeCards({
+  isLoggedIn = false,
+  isAdmin = false,
+  hasFriendCode = false,
+} = {}) {
+  const memberAccess = isLoggedIn || isAdmin
 
   return [
     ...PUBLIC_CARDS,
-    ...(memberAccess ? MEMBER_CARDS : []),
+    ...(memberAccess ? [...MEMBER_CARDS, getTradeCard(hasFriendCode)] : []),
     ...(isAdmin ? ADMIN_CARDS : []),
-  ];
+  ]
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,62 +2,12 @@ import Head from "next/head"
 import Link from "next/link"
 import { getServerSession } from "next-auth/next"
 import { getHomeCards } from "../lib/homeCards"
-import prisma from "../lib/prisma"
-import {
-  getEligibleTradeUser,
-  purgeExpiredTradeListings,
-  tradeListingInclude,
-} from "../lib/tradeServer"
-import { serializeTradeListing } from "../lib/tradeUtils"
+import { getEligibleTradeUser } from "../lib/tradeServer"
 import styles from "../styles/HomeDashboard.module.css"
 import { authOptions } from "./api/auth/[...nextauth]"
 
-const itemNames = (listing, direction) =>
-  listing.items
-    .filter((item) => item.direction === direction)
-    .map((item) => item.pokemonName)
-    .join(", ")
-
-function HomeTradeListing({ listing }) {
-  return (
-    <article className={`card trade-listing-card ${styles.tradeListing}`}>
-      <div className="trade-section-header">
-        <div>
-          <h3 className={styles.tradeTitle}>
-            <Link href={`/trades/${listing.id}`}>Trade listing #{listing.id}</Link>
-          </h3>
-          <p className="muted">Listed by {listing.owner.ign}</p>
-        </div>
-        <span className="trade-status active">ACTIVE</span>
-      </div>
-
-      <div className="trade-summary-grid">
-        <div>
-          <strong>Offering</strong>
-          <p>{itemNames(listing, "OFFER")}</p>
-        </div>
-        <div>
-          <strong>Wanted</strong>
-          <p>{itemNames(listing, "WANT")}</p>
-        </div>
-      </div>
-
-      {listing.location && <p className="muted">Location: {listing.location}</p>}
-      <p className="muted">
-        Expires {new Date(listing.expiresAt).toLocaleDateString("en-GB")}
-      </p>
-
-      <div className="trade-card-actions">
-        <Link className="button-link" href={`/trades/${listing.id}`}>
-          View listing
-        </Link>
-      </div>
-    </article>
-  )
-}
-
-export default function Home({ isLoggedIn, isAdmin, tradeListings }) {
-  const cards = getHomeCards({ isLoggedIn, isAdmin })
+export default function Home({ isLoggedIn, isAdmin, hasFriendCode }) {
+  const cards = getHomeCards({ isLoggedIn, isAdmin, hasFriendCode })
 
   return (
     <>
@@ -81,7 +31,7 @@ export default function Home({ isLoggedIn, isAdmin, tradeListings }) {
         <section className={styles.grid} aria-label="Community sections">
           {cards.map((card) => (
             <Link
-              key={card.href}
+              key={card.title}
               href={card.href}
               className={`${styles.card} ${styles[card.tone]}`}
             >
@@ -97,40 +47,6 @@ export default function Home({ isLoggedIn, isAdmin, tradeListings }) {
           ))}
         </section>
 
-        {isLoggedIn && (
-          <section className={styles.tradeSection} aria-labelledby="home-trade-listings">
-            <div className={styles.tradeHeader}>
-              <div>
-                <p className={styles.eyebrow}>Registered members only</p>
-                <h2 id="home-trade-listings">Active trade listings</h2>
-                <p className={styles.tradeIntro}>
-                  Browse current offers without leaving the community homepage.
-                </p>
-              </div>
-              <div className="trade-card-actions">
-                <Link className="button-link secondary-button" href="/trades">
-                  View all trades
-                </Link>
-                <Link className="button-link" href="/trades/new">
-                  Create listing
-                </Link>
-              </div>
-            </div>
-
-            {tradeListings.length === 0 ? (
-              <div className={`card ${styles.emptyTrades}`}>
-                <p className="muted">There are no active trade listings yet.</p>
-              </div>
-            ) : (
-              <div className={styles.tradeList}>
-                {tradeListings.map((listing) => (
-                  <HomeTradeListing key={listing.id} listing={listing} />
-                ))}
-              </div>
-            )}
-          </section>
-        )}
-
         {!isLoggedIn && (
           <p className={styles.loginNote}>
             <Link href="/login">Log in</Link> to unlock community guides and the private gym map.
@@ -144,40 +60,13 @@ export default function Home({ isLoggedIn, isAdmin, tradeListings }) {
 export async function getServerSideProps(context) {
   const session = await getServerSession(context.req, context.res, authOptions)
   const role = session?.user?.role
-
-  if (!session) {
-    return {
-      props: {
-        isLoggedIn: false,
-        isAdmin: false,
-        tradeListings: [],
-      },
-    }
-  }
-
-  const tradeUser = await getEligibleTradeUser(session)
-
-  if (!tradeUser) {
-    return {
-      redirect: { destination: "/friend-codes", permanent: false },
-    }
-  }
-
-  await purgeExpiredTradeListings()
-  const tradeListings = await prisma.tradeListing.findMany({
-    where: {
-      status: "ACTIVE",
-      expiresAt: { gt: new Date() },
-    },
-    include: tradeListingInclude,
-    orderBy: { createdAt: "desc" },
-  })
+  const tradeUser = session ? await getEligibleTradeUser(session) : null
 
   return {
     props: {
-      isLoggedIn: true,
+      isLoggedIn: Boolean(session),
       isAdmin: role === "admin",
-      tradeListings: tradeListings.map(serializeTradeListing),
+      hasFriendCode: Boolean(tradeUser),
     },
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,10 +2,61 @@ import Head from "next/head"
 import Link from "next/link"
 import { getServerSession } from "next-auth/next"
 import { getHomeCards } from "../lib/homeCards"
+import prisma from "../lib/prisma"
+import {
+  getEligibleTradeUser,
+  purgeExpiredTradeListings,
+  tradeListingInclude,
+} from "../lib/tradeServer"
+import { serializeTradeListing } from "../lib/tradeUtils"
 import styles from "../styles/HomeDashboard.module.css"
 import { authOptions } from "./api/auth/[...nextauth]"
 
-export default function Home({ isLoggedIn, isAdmin }) {
+const itemNames = (listing, direction) =>
+  listing.items
+    .filter((item) => item.direction === direction)
+    .map((item) => item.pokemonName)
+    .join(", ")
+
+function HomeTradeListing({ listing }) {
+  return (
+    <article className={`card trade-listing-card ${styles.tradeListing}`}>
+      <div className="trade-section-header">
+        <div>
+          <h3 className={styles.tradeTitle}>
+            <Link href={`/trades/${listing.id}`}>Trade listing #{listing.id}</Link>
+          </h3>
+          <p className="muted">Listed by {listing.owner.ign}</p>
+        </div>
+        <span className="trade-status active">ACTIVE</span>
+      </div>
+
+      <div className="trade-summary-grid">
+        <div>
+          <strong>Offering</strong>
+          <p>{itemNames(listing, "OFFER")}</p>
+        </div>
+        <div>
+          <strong>Wanted</strong>
+          <p>{itemNames(listing, "WANT")}</p>
+        </div>
+      </div>
+
+      {listing.location && <p className="muted">Location: {listing.location}</p>}
+      <p className="muted">
+        Expires {new Date(listing.expiresAt).toLocaleDateString("en-GB")}
+      </p>
+
+      <div className="trade-card-actions">
+        <Link className="button-link" href={`/trades/${listing.id}`}>
+          View listing
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+export default function Home({ isLoggedIn, isAdmin, tradeListings }) {
   const cards = getHomeCards({ isLoggedIn, isAdmin })
 
   return (
@@ -46,6 +97,40 @@ export default function Home({ isLoggedIn, isAdmin }) {
           ))}
         </section>
 
+        {isLoggedIn && (
+          <section className={styles.tradeSection} aria-labelledby="home-trade-listings">
+            <div className={styles.tradeHeader}>
+              <div>
+                <p className={styles.eyebrow}>Registered members only</p>
+                <h2 id="home-trade-listings">Active trade listings</h2>
+                <p className={styles.tradeIntro}>
+                  Browse current offers without leaving the community homepage.
+                </p>
+              </div>
+              <div className="trade-card-actions">
+                <Link className="button-link secondary-button" href="/trades">
+                  View all trades
+                </Link>
+                <Link className="button-link" href="/trades/new">
+                  Create listing
+                </Link>
+              </div>
+            </div>
+
+            {tradeListings.length === 0 ? (
+              <div className={`card ${styles.emptyTrades}`}>
+                <p className="muted">There are no active trade listings yet.</p>
+              </div>
+            ) : (
+              <div className={styles.tradeList}>
+                {tradeListings.map((listing) => (
+                  <HomeTradeListing key={listing.id} listing={listing} />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
         {!isLoggedIn && (
           <p className={styles.loginNote}>
             <Link href="/login">Log in</Link> to unlock community guides and the private gym map.
@@ -60,10 +145,39 @@ export async function getServerSideProps(context) {
   const session = await getServerSession(context.req, context.res, authOptions)
   const role = session?.user?.role
 
+  if (!session) {
+    return {
+      props: {
+        isLoggedIn: false,
+        isAdmin: false,
+        tradeListings: [],
+      },
+    }
+  }
+
+  const tradeUser = await getEligibleTradeUser(session)
+
+  if (!tradeUser) {
+    return {
+      redirect: { destination: "/friend-codes", permanent: false },
+    }
+  }
+
+  await purgeExpiredTradeListings()
+  const tradeListings = await prisma.tradeListing.findMany({
+    where: {
+      status: "ACTIVE",
+      expiresAt: { gt: new Date() },
+    },
+    include: tradeListingInclude,
+    orderBy: { createdAt: "desc" },
+  })
+
   return {
     props: {
-      isLoggedIn: Boolean(session),
+      isLoggedIn: true,
       isAdmin: role === "admin",
+      tradeListings: tradeListings.map(serializeTradeListing),
     },
   }
 }

--- a/pages/trades/[id].js
+++ b/pages/trades/[id].js
@@ -171,7 +171,7 @@ export async function getServerSideProps(context) {
 
   if (!tradeUser) {
     return {
-      redirect: { destination: "/trades", permanent: false },
+      redirect: { destination: "/friend-codes", permanent: false },
     }
   }
 

--- a/pages/trades/[id]/edit.js
+++ b/pages/trades/[id]/edit.js
@@ -85,7 +85,7 @@ export async function getServerSideProps(context) {
 
   if (!tradeUser) {
     return {
-      redirect: { destination: "/trades", permanent: false },
+      redirect: { destination: "/friend-codes", permanent: false },
     }
   }
 

--- a/pages/trades/index.js
+++ b/pages/trades/index.js
@@ -66,7 +66,7 @@ function ListingCard({ listing, mine = false, onClose }) {
   )
 }
 
-export default function TradesPage({ requiresFriendCode, listings, myListings }) {
+export default function TradesPage({ listings, myListings }) {
   const router = useRouter()
 
   const closeListing = async (listingId) => {
@@ -87,25 +87,6 @@ export default function TradesPage({ requiresFriendCode, listings, myListings })
     }
 
     router.replace(router.asPath)
-  }
-
-  if (requiresFriendCode) {
-    return (
-      <div className="container">
-        <div className="card">
-          <h1>Trade listings</h1>
-          <p>
-            You need a valid 12-digit Pokémon GO friend code saved to your account
-            before you can view or create trade listings.
-          </p>
-          <div className="trade-card-actions">
-            <Link className="button-link" href="/account">
-              Add friend code
-            </Link>
-          </div>
-        </div>
-      </div>
-    )
   }
 
   return (
@@ -169,11 +150,7 @@ export async function getServerSideProps(context) {
 
   if (!tradeUser) {
     return {
-      props: {
-        requiresFriendCode: true,
-        listings: [],
-        myListings: [],
-      },
+      redirect: { destination: "/friend-codes", permanent: false },
     }
   }
 
@@ -201,7 +178,6 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
-      requiresFriendCode: false,
       listings: listings.map(serializeTradeListing),
       myListings: myListings.map(serializeTradeListing),
     },

--- a/pages/trades/new.js
+++ b/pages/trades/new.js
@@ -71,7 +71,7 @@ export async function getServerSideProps(context) {
 
   if (!tradeUser) {
     return {
-      redirect: { destination: "/trades", permanent: false },
+      redirect: { destination: "/friend-codes", permanent: false },
     }
   }
 

--- a/styles/HomeDashboard.module.css
+++ b/styles/HomeDashboard.module.css
@@ -124,6 +124,12 @@
     #161b22;
 }
 
+.trades {
+  background:
+    radial-gradient(circle at top right, rgba(248, 81, 73, 0.2), transparent 42%),
+    #161b22;
+}
+
 .admin {
   grid-column: 1 / -1;
   min-height: 180px;
@@ -136,57 +142,6 @@
 .admin .label {
   border-color: #6e5500;
   color: #f2cc60;
-}
-
-.tradeSection {
-  margin-top: 38px;
-}
-
-.tradeHeader {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 16px;
-}
-
-.tradeHeader h2 {
-  margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.5rem);
-}
-
-.tradeIntro {
-  margin: 8px 0 0;
-  color: #8b949e;
-  line-height: 1.5;
-}
-
-.tradeList {
-  display: grid;
-  gap: 16px;
-}
-
-.tradeListing {
-  margin-bottom: 0;
-}
-
-.tradeTitle {
-  margin: 0;
-  font-size: 1.35rem;
-}
-
-.tradeTitle a {
-  color: #9ecbff;
-  text-decoration: none;
-}
-
-.tradeTitle a:hover,
-.tradeTitle a:focus-visible {
-  text-decoration: underline;
-}
-
-.emptyTrades {
-  margin-bottom: 0;
 }
 
 .loginNote {
@@ -215,19 +170,6 @@
 
   .card {
     min-height: 185px;
-  }
-
-  .tradeHeader {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .tradeHeader :global(.trade-card-actions) {
-    width: 100%;
-  }
-
-  .tradeHeader :global(.trade-card-actions) > * {
-    width: 100%;
   }
 }
 

--- a/styles/HomeDashboard.module.css
+++ b/styles/HomeDashboard.module.css
@@ -138,6 +138,57 @@
   color: #f2cc60;
 }
 
+.tradeSection {
+  margin-top: 38px;
+}
+
+.tradeHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 16px;
+}
+
+.tradeHeader h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+}
+
+.tradeIntro {
+  margin: 8px 0 0;
+  color: #8b949e;
+  line-height: 1.5;
+}
+
+.tradeList {
+  display: grid;
+  gap: 16px;
+}
+
+.tradeListing {
+  margin-bottom: 0;
+}
+
+.tradeTitle {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.tradeTitle a {
+  color: #9ecbff;
+  text-decoration: none;
+}
+
+.tradeTitle a:hover,
+.tradeTitle a:focus-visible {
+  text-decoration: underline;
+}
+
+.emptyTrades {
+  margin-bottom: 0;
+}
+
 .loginNote {
   margin: 20px 0 0;
   color: #8b949e;
@@ -164,6 +215,19 @@
 
   .card {
     min-height: 185px;
+  }
+
+  .tradeHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tradeHeader :global(.trade-card-actions) {
+    width: 100%;
+  }
+
+  .tradeHeader :global(.trade-card-actions) > * {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## What changed

- adds a registered-members-only Trade Listings card to the homepage
- sends members with a valid stored friend code to `/trades`
- sends members without a valid friend code to `/friend-codes`
- keeps logged-out visitors from seeing the Trade Listings card
- redirects all protected trade pages to `/friend-codes` when the signed-in user has no valid friend code
- does not load or display individual trade listings on the homepage

## Validation

This PR targets `develop` and will use the repository's existing validation workflow for lint, tests and production build.