### PR TITLE
Add season-aware Ditto disguise ticker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .nextauth-secret
 /data/.cache/
 /data/events-cache.json*
+/data/ditto-disguises-cache.json*
 /data/local-events.json*
 /data/event-overrides.json*
 /data/event-type-rules.json*

--- a/__tests__/components/tickers.test.js
+++ b/__tests__/components/tickers.test.js
@@ -6,8 +6,10 @@ function readSource(relativePath) {
 }
 
 describe("ticker regression wiring", () => {
+  const app = readSource("pages/_app.js");
   const eventTicker = readSource("components/events/EventTicker.tsx");
   const raidTicker = readSource("components/events/RaidBossTicker.tsx");
+  const dittoTicker = readSource("components/events/DittoDisguiseTicker.tsx");
 
   it("uses a Campfire URL as the primary event link with an Events-page fallback", () => {
     expect(eventTicker).toMatch(
@@ -28,6 +30,21 @@ describe("ticker regression wiring", () => {
     expect(raidTicker).toContain("animation-play-state: paused;");
     expect(raidTicker).toContain(".raid-group-duplicate");
     expect(raidTicker).toContain("display: none;");
+  });
+
+  it("keeps the Ditto ticker public and between raids and new gyms", () => {
+    expect(dittoTicker).toContain('fetch("/api/ditto-disguises"');
+    expect(dittoTicker).not.toContain("useSession");
+    expect(dittoTicker).toContain("<DittoItems disguises={disguises} />");
+    expect(dittoTicker).toContain("<DittoItems disguises={disguises} duplicate />");
+
+    const raidPosition = app.indexOf("<RaidBossTicker />");
+    const dittoPosition = app.indexOf("<DittoDisguiseTicker />");
+    const gymPosition = app.indexOf("<NewGymTicker />");
+
+    expect(raidPosition).toBeGreaterThan(-1);
+    expect(dittoPosition).toBeGreaterThan(raidPosition);
+    expect(gymPosition).toBeGreaterThan(dittoPosition);
   });
 
   it("retains matching speed and interaction behaviour", () => {

--- a/__tests__/lib/ditto-disguises.test.js
+++ b/__tests__/lib/ditto-disguises.test.js
@@ -1,0 +1,97 @@
+const {
+  isDittoCacheForSeason,
+  normaliseDittoDisguises,
+} = require("../../lib/ditto-disguises")
+const {
+  selectCurrentPokemonGoSeason,
+} = require("../../lib/season-server")
+
+describe("Ditto disguise helpers", () => {
+  it("normalises, sorts and de-duplicates the PoGoAPI object payload", () => {
+    expect(
+      normaliseDittoDisguises({
+        50: { id: 50, name: "Diglett" },
+        bad: { id: "not-a-number", name: "MissingNo" },
+        duplicate: { id: 50, name: "Diglett" },
+        19: { id: "19", name: "Rattata" },
+      }),
+    ).toEqual([
+      { id: 19, name: "Rattata" },
+      { id: 50, name: "Diglett" },
+    ])
+  })
+
+  it("keeps the cache while the ScrapedDuck season ID is unchanged", () => {
+    expect(
+      isDittoCacheForSeason(
+        "season-23-forever-forward",
+        "season-23-forever-forward",
+      ),
+    ).toBe(true)
+    expect(
+      isDittoCacheForSeason(
+        "season-23-forever-forward",
+        "season-24-next-season",
+      ),
+    ).toBe(false)
+  })
+
+  it("selects the active ScrapedDuck season using London-local timestamps", () => {
+    const events = [
+      {
+        eventID: "season-old",
+        name: "Old Season",
+        eventType: "season",
+        heading: "Season",
+        link: null,
+        image: null,
+        start: "2026-03-01T10:00:00.000",
+        end: "2026-06-02T10:00:00.000",
+      },
+      {
+        eventID: "season-23-forever-forward",
+        name: "Forever Forward",
+        eventType: "season",
+        heading: "Season",
+        link: null,
+        image: null,
+        start: "2026-06-02T10:00:00.000",
+        end: "2026-09-08T10:00:00.000",
+      },
+    ]
+
+    expect(
+      selectCurrentPokemonGoSeason(
+        events,
+        new Date("2026-07-31T15:00:00.000Z"),
+      ),
+    ).toEqual({
+      eventID: "season-23-forever-forward",
+      name: "Forever Forward",
+      start: "2026-06-02T10:00:00.000",
+      end: "2026-09-08T10:00:00.000",
+    })
+  })
+
+  it("stops using a season at its exact ScrapedDuck end time", () => {
+    const events = [
+      {
+        eventID: "season-23-forever-forward",
+        name: "Forever Forward",
+        eventType: "season",
+        heading: "Season",
+        link: null,
+        image: null,
+        start: "2026-06-02T10:00:00.000",
+        end: "2026-09-08T10:00:00.000",
+      },
+    ]
+
+    expect(
+      selectCurrentPokemonGoSeason(
+        events,
+        new Date("2026-09-08T09:00:00.000Z"),
+      ),
+    ).toBeNull()
+  })
+})

--- a/components/events/DittoDisguiseTicker.tsx
+++ b/components/events/DittoDisguiseTicker.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import type {
+  DittoDisguise,
+  DittoDisguisePayload,
+  DittoSeason,
+} from "../../lib/ditto-disguises";
+
+type DittoTickerStatus = "loading" | "ready" | "error";
+
+const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+function DittoItems({
+  disguises,
+  duplicate = false,
+}: {
+  disguises: DittoDisguise[];
+  duplicate?: boolean;
+}) {
+  return (
+    <div
+      className={`ditto-group${duplicate ? " ditto-group-duplicate" : ""}`}
+      aria-hidden={duplicate || undefined}
+    >
+      {disguises.map((disguise) => (
+        <span
+          className="ditto-item"
+          key={`${duplicate ? "duplicate-" : ""}${disguise.id}`}
+        >
+          <span className="ditto-ball" aria-hidden="true">◓</span>
+          <strong>{disguise.name}</strong>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function DittoDisguiseTicker() {
+  const [disguises, setDisguises] = useState<DittoDisguise[]>([]);
+  const [season, setSeason] = useState<DittoSeason | null>(null);
+  const [status, setStatus] = useState<DittoTickerStatus>("loading");
+
+  useEffect(() => {
+    let controller: AbortController | null = null;
+
+    async function loadDisguises() {
+      controller?.abort();
+      controller = new AbortController();
+
+      try {
+        const response = await fetch("/api/ditto-disguises", {
+          signal: controller.signal,
+          cache: "no-store",
+          headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+          setStatus("error");
+          return;
+        }
+
+        const payload = (await response.json()) as DittoDisguisePayload;
+        setDisguises(
+          Array.isArray(payload.disguises) ? payload.disguises : [],
+        );
+        setSeason(payload.season ?? null);
+        setStatus("ready");
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          console.error("Failed to load current Ditto disguises", error);
+          setStatus("error");
+        }
+      }
+    }
+
+    const refresh = () => void loadDisguises();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refresh();
+      }
+    };
+
+    refresh();
+    const timer = window.setInterval(refresh, REFRESH_INTERVAL_MS);
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      controller?.abort();
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
+  const animationDuration = useMemo(
+    () => `${Math.max(32, disguises.length * 8)}s`,
+    [disguises.length],
+  );
+  const message =
+    status === "loading"
+      ? "Loading current Ditto disguises…"
+      : status === "error"
+        ? "Ditto disguises temporarily unavailable"
+        : "No current Ditto disguises listed";
+
+  return (
+    <section
+      className="ditto-ticker"
+      aria-label={
+        season
+          ? `Current Ditto disguises during ${season.name}`
+          : "Current Ditto disguises"
+      }
+      title={season ? `Pokémon GO season: ${season.name}` : undefined}
+    >
+      <div className="ditto-label">
+        <span aria-hidden="true">◆</span>
+        Ditto disguises
+      </div>
+
+      <div className="ditto-viewport">
+        {disguises.length > 0 ? (
+          <div
+            className="ditto-track"
+            style={
+              {
+                "--ditto-ticker-duration": animationDuration,
+              } as CSSProperties
+            }
+          >
+            <DittoItems disguises={disguises} />
+            <DittoItems disguises={disguises} duplicate />
+          </div>
+        ) : (
+          <p className="ditto-message" role="status">
+            {message}
+          </p>
+        )}
+      </div>
+
+      <style jsx>{`
+        .ditto-ticker {
+          display: flex;
+          min-height: 38px;
+          align-items: stretch;
+          overflow: hidden;
+          border-bottom: 1px solid #30363d;
+          background: #15111d;
+          color: #f0f6fc;
+        }
+
+        .ditto-label {
+          position: relative;
+          z-index: 2;
+          display: flex;
+          flex: 0 0 auto;
+          align-items: center;
+          gap: 7px;
+          padding: 0 15px;
+          border-right: 1px solid #49365f;
+          background: #100d16;
+          color: #d2a8ff;
+          font-size: 0.74rem;
+          font-weight: 800;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+        }
+
+        .ditto-label span {
+          color: #bc8cff;
+          font-size: 0.62rem;
+        }
+
+        .ditto-viewport {
+          min-width: 0;
+          flex: 1;
+          overflow: hidden;
+          mask-image: linear-gradient(
+            to right,
+            transparent,
+            black 18px,
+            black calc(100% - 18px),
+            transparent
+          );
+        }
+
+        .ditto-track {
+          display: flex;
+          width: max-content;
+          min-width: 100%;
+          animation: ditto-ticker-scroll var(--ditto-ticker-duration) linear infinite;
+          will-change: transform;
+        }
+
+        .ditto-ticker:hover .ditto-track,
+        .ditto-ticker:focus-within .ditto-track {
+          animation-play-state: paused;
+        }
+
+        .ditto-message {
+          margin: 0;
+          padding: 0 18px;
+          color: #8b949e;
+          font-size: 0.82rem;
+          line-height: 38px;
+          white-space: nowrap;
+        }
+
+        @keyframes ditto-ticker-scroll {
+          from {
+            transform: translateX(0);
+          }
+          to {
+            transform: translateX(-50%);
+          }
+        }
+
+        @media (max-width: 620px) {
+          .ditto-label {
+            padding: 0 10px;
+            font-size: 0.68rem;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .ditto-viewport {
+            overflow-x: auto;
+            mask-image: none;
+          }
+
+          .ditto-track {
+            animation: none;
+          }
+        }
+      `}</style>
+
+      <style jsx global>{`
+        .ditto-group {
+          display: flex;
+          flex: 0 0 auto;
+          align-items: stretch;
+        }
+
+        .ditto-item {
+          display: inline-flex;
+          align-items: center;
+          gap: 7px;
+          padding: 0 16px;
+          color: #d8c9e8;
+          font-size: 0.82rem;
+          line-height: 38px;
+          white-space: nowrap;
+        }
+
+        .ditto-item::after {
+          content: "◆";
+          margin-left: 8px;
+          color: #49365f;
+          font-size: 0.5rem;
+        }
+
+        .ditto-ball {
+          color: #bc8cff;
+          font-size: 0.9rem;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .ditto-group-duplicate {
+            display: none;
+          }
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/lib/ditto-disguises-server.ts
+++ b/lib/ditto-disguises-server.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  isDittoCacheForSeason,
+  normaliseDittoDisguises,
+  type DittoDisguisePayload,
+  type DittoSeason,
+} from "./ditto-disguises";
+import {
+  getCurrentPokemonGoSeason,
+  type PokemonGoSeasonBoundary,
+} from "./season-server";
+
+const DITTO_FEED_URL =
+  "https://pogoapi.net/api/v1/possible_ditto_pokemon.json";
+const DITTO_CACHE_VERSION = 1;
+const DITTO_CACHE_PATH =
+  process.env.DITTO_CACHE_PATH?.trim() ||
+  path.join(process.cwd(), "data", "ditto-disguises-cache.json");
+
+interface StoredDittoCache extends DittoDisguisePayload {
+  version: number;
+  season: DittoSeason;
+}
+
+let refreshInFlight: Promise<StoredDittoCache> | null = null;
+
+function requiredString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normaliseSeason(value: unknown): DittoSeason | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const eventID = requiredString(candidate.eventID);
+  const name = requiredString(candidate.name);
+  const start = requiredString(candidate.start);
+  const end = requiredString(candidate.end);
+
+  return eventID && name && start && end
+    ? { eventID, name, start, end }
+    : null;
+}
+
+async function readDittoCache(): Promise<StoredDittoCache | null> {
+  try {
+    const source = await fs.readFile(DITTO_CACHE_PATH, "utf8");
+    const parsed: unknown = JSON.parse(source);
+
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    const candidate = parsed as Record<string, unknown>;
+    const fetchedAt = requiredString(candidate.fetchedAt);
+    const season = normaliseSeason(candidate.season);
+    const disguises = normaliseDittoDisguises(candidate.disguises);
+
+    if (
+      candidate.version !== DITTO_CACHE_VERSION ||
+      !fetchedAt ||
+      !season ||
+      disguises.length === 0
+    ) {
+      return null;
+    }
+
+    return {
+      version: DITTO_CACHE_VERSION,
+      fetchedAt,
+      season,
+      disguises,
+      isStale: false,
+      warning: null,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+
+    if (code === "ENOENT" || error instanceof SyntaxError) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+async function writeDittoCache(cache: StoredDittoCache): Promise<void> {
+  const directory = path.dirname(DITTO_CACHE_PATH);
+  const temporaryPath = `${DITTO_CACHE_PATH}.${process.pid}.${Date.now()}.tmp`;
+
+  await fs.mkdir(directory, { recursive: true });
+
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(cache)}\n`, "utf8");
+    await fs.rename(temporaryPath, DITTO_CACHE_PATH);
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+async function fetchLatestDisguises(
+  season: PokemonGoSeasonBoundary,
+): Promise<StoredDittoCache> {
+  const response = await fetch(DITTO_FEED_URL, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `PoGoAPI Ditto feed returned ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const disguises = normaliseDittoDisguises(await response.json());
+
+  if (disguises.length === 0) {
+    throw new Error("PoGoAPI Ditto feed did not contain any disguises");
+  }
+
+  const cache: StoredDittoCache = {
+    version: DITTO_CACHE_VERSION,
+    fetchedAt: new Date().toISOString(),
+    season,
+    disguises,
+    isStale: false,
+    warning: null,
+  };
+
+  await writeDittoCache(cache);
+
+  return cache;
+}
+
+async function refreshDittoCache(
+  season: PokemonGoSeasonBoundary,
+): Promise<StoredDittoCache> {
+  if (!refreshInFlight) {
+    refreshInFlight = fetchLatestDisguises(season).finally(() => {
+      refreshInFlight = null;
+    });
+  }
+
+  return refreshInFlight;
+}
+
+function staleFallback(
+  cache: StoredDittoCache,
+  error: unknown,
+): DittoDisguisePayload {
+  return {
+    disguises: cache.disguises,
+    season: cache.season,
+    fetchedAt: cache.fetchedAt,
+    isStale: true,
+    warning:
+      error instanceof Error
+        ? `The Ditto disguise refresh failed: ${error.message}`
+        : "The Ditto disguise refresh failed.",
+  };
+}
+
+export async function getDittoDisguiseData(): Promise<DittoDisguisePayload> {
+  const cache = await readDittoCache();
+  let season: PokemonGoSeasonBoundary | null;
+
+  try {
+    season = await getCurrentPokemonGoSeason();
+  } catch (error) {
+    if (cache) {
+      return staleFallback(cache, error);
+    }
+
+    throw error;
+  }
+
+  if (!season) {
+    const error = new Error("ScrapedDuck did not provide an active season");
+
+    if (cache) {
+      return staleFallback(cache, error);
+    }
+
+    throw error;
+  }
+
+  if (cache && isDittoCacheForSeason(cache.season.eventID, season.eventID)) {
+    return {
+      disguises: cache.disguises,
+      season: cache.season,
+      fetchedAt: cache.fetchedAt,
+      isStale: false,
+      warning: null,
+    };
+  }
+
+  try {
+    return await refreshDittoCache(season);
+  } catch (error) {
+    if (cache) {
+      return staleFallback(cache, error);
+    }
+
+    throw error;
+  }
+}

--- a/lib/ditto-disguises.ts
+++ b/lib/ditto-disguises.ts
@@ -1,0 +1,61 @@
+export interface DittoDisguise {
+  id: number;
+  name: string;
+}
+
+export interface DittoSeason {
+  eventID: string;
+  name: string;
+  start: string;
+  end: string;
+}
+
+export interface DittoDisguisePayload {
+  disguises: DittoDisguise[];
+  season: DittoSeason | null;
+  fetchedAt: string;
+  isStale: boolean;
+  warning: string | null;
+}
+
+export function normaliseDittoDisguises(payload: unknown): DittoDisguise[] {
+  const values = Array.isArray(payload)
+    ? payload
+    : payload && typeof payload === "object"
+      ? Object.values(payload as Record<string, unknown>)
+      : [];
+  const disguises = values
+    .map((value): DittoDisguise | null => {
+      if (!value || typeof value !== "object") {
+        return null;
+      }
+
+      const candidate = value as Record<string, unknown>;
+      const id = Number(candidate.id);
+      const name =
+        typeof candidate.name === "string" ? candidate.name.trim() : "";
+
+      if (!Number.isInteger(id) || id <= 0 || !name) {
+        return null;
+      }
+
+      return { id, name };
+    })
+    .filter((item): item is DittoDisguise => item !== null)
+    .sort((left, right) => left.id - right.id);
+
+  return Array.from(
+    new Map(disguises.map((disguise) => [disguise.id, disguise])).values(),
+  );
+}
+
+export function isDittoCacheForSeason(
+  cachedSeasonID: string | null | undefined,
+  currentSeasonID: string | null | undefined,
+): boolean {
+  return Boolean(
+    cachedSeasonID &&
+      currentSeasonID &&
+      cachedSeasonID === currentSeasonID,
+  );
+}

--- a/lib/season-server.ts
+++ b/lib/season-server.ts
@@ -1,0 +1,101 @@
+import type { PokemonGoEventSummary } from "./events";
+import {
+  forceRefreshEventsCache,
+  getEventsPageData,
+} from "./events-server";
+
+export interface PokemonGoSeasonBoundary {
+  eventID: string;
+  name: string;
+  start: string;
+  end: string;
+}
+
+const EXPLICIT_TIME_ZONE = /(?:Z|[+-]\d{2}:\d{2})$/i;
+
+function londonWallClock(now: Date): string {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+
+  return `${values.year}-${values.month}-${values.day}T${values.hour}:${values.minute}:${values.second}`;
+}
+
+function timestampPosition(value: string, now: Date): number {
+  if (EXPLICIT_TIME_ZONE.test(value)) {
+    const timestamp = Date.parse(value);
+
+    return Number.isFinite(timestamp) ? timestamp - now.getTime() : Number.NaN;
+  }
+
+  return value.slice(0, 19).localeCompare(londonWallClock(now));
+}
+
+function isActiveSeason(
+  event: PokemonGoEventSummary,
+  now: Date,
+): boolean {
+  if (event.eventType !== "season") {
+    return false;
+  }
+
+  const startPosition = timestampPosition(event.start, now);
+  const endPosition = timestampPosition(event.end, now);
+
+  return (
+    Number.isFinite(startPosition) &&
+    Number.isFinite(endPosition) &&
+    startPosition <= 0 &&
+    endPosition > 0
+  );
+}
+
+export function selectCurrentPokemonGoSeason(
+  events: PokemonGoEventSummary[],
+  now: Date = new Date(),
+): PokemonGoSeasonBoundary | null {
+  const season = events
+    .filter((event) => isActiveSeason(event, now))
+    .sort((left, right) => right.start.localeCompare(left.start))[0];
+
+  if (!season) {
+    return null;
+  }
+
+  return {
+    eventID: season.eventID,
+    name: season.name,
+    start: season.start,
+    end: season.end,
+  };
+}
+
+export async function getCurrentPokemonGoSeason(
+  now: Date = new Date(),
+): Promise<PokemonGoSeasonBoundary | null> {
+  const cachedEvents = await getEventsPageData(300);
+  const cachedSeason = selectCurrentPokemonGoSeason(cachedEvents.events, now);
+
+  if (cachedSeason) {
+    return cachedSeason;
+  }
+
+  // A missing active season normally means the previous season's exact end
+  // timestamp has passed. Refresh ScrapedDuck immediately instead of waiting
+  // for the normal weekly events-cache refresh.
+  const refreshedEvents = await forceRefreshEventsCache(300);
+
+  return selectCurrentPokemonGoSeason(refreshedEvents.events, now);
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import "../styles/tickers.css"
 import "../styles/gyms.css"
 import "../styles/trades.css"
 import Navbar from "../components/Navbar"
+import DittoDisguiseTicker from "../components/events/DittoDisguiseTicker"
 import EventTicker from "../components/events/EventTicker"
 import RaidBossTicker from "../components/events/RaidBossTicker"
 import NewGymTicker from "../components/gyms/NewGymTicker"
@@ -20,6 +21,7 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
       <Navbar />
       {showEventTicker && <EventTicker />}
       <RaidBossTicker />
+      <DittoDisguiseTicker />
       <NewGymTicker />
       <Component {...pageProps} />
     </SessionProvider>

--- a/pages/api/ditto-disguises.ts
+++ b/pages/api/ditto-disguises.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { DittoDisguisePayload } from "../../lib/ditto-disguises";
+import { getDittoDisguiseData } from "../../lib/ditto-disguises-server";
+
+type DittoDisguiseResponse = DittoDisguisePayload | { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<DittoDisguiseResponse>,
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const payload = await getDittoDisguiseData();
+
+    res.setHeader(
+      "Cache-Control",
+      "public, max-age=300, s-maxage=300, stale-while-revalidate=86400",
+    );
+
+    return res.status(200).json(payload);
+  } catch (error) {
+    console.error("Failed to load current Ditto disguises", error);
+
+    return res.status(502).json({
+      error:
+        error instanceof Error
+          ? error.message
+          : "The current Ditto disguises could not be loaded.",
+    });
+  }
+}


### PR DESCRIPTION
## What changed

- adds a new public Ditto disguise ticker between Current Raids and New Gyms
- fetches disguise IDs and names from PoGoAPI's `possible_ditto_pokemon.json`
- stores the last successful disguise list in `data/ditto-disguises-cache.json`
- keys that cache to the active ScrapedDuck `eventType: season` event ID
- refreshes the ScrapedDuck events feed immediately when the cached season's exact end time passes
- downloads PoGoAPI again only when the active season ID changes
- serves the last good disguise cache if either upstream is temporarily unavailable
- adds a public `/api/ditto-disguises` endpoint with short HTTP caching
- adds tests for payload normalisation, de-duplication, London-local season boundaries, cache season matching, public visibility, and ticker placement

## Data sources

- PoGoAPI: `https://pogoapi.net/api/v1/possible_ditto_pokemon.json`
- ScrapedDuck events feed already used by the application

## Validation

The repository's existing Validate workflow will run dependency audits, ESLint, Jest, and the Next.js production build.