### PR TITLE
Fix Ditto API caching

### DIFF
--- a/__tests__/components/tickers.test.js
+++ b/__tests__/components/tickers.test.js
@@ -10,6 +10,7 @@ describe("ticker regression wiring", () => {
   const eventTicker = readSource("components/events/EventTicker.tsx");
   const raidTicker = readSource("components/events/RaidBossTicker.tsx");
   const dittoTicker = readSource("components/events/DittoDisguiseTicker.tsx");
+  const dittoApi = readSource("pages/api/ditto-disguises.ts");
 
   it("uses a Campfire URL as the primary event link with an Events-page fallback", () => {
     expect(eventTicker).toMatch(
@@ -32,9 +33,12 @@ describe("ticker regression wiring", () => {
     expect(raidTicker).toContain("display: none;");
   });
 
-  it("keeps the Ditto ticker public and between raids and new gyms", () => {
+  it("keeps the Ditto ticker public, cached and between raids and new gyms", () => {
     expect(dittoTicker).toContain('fetch("/api/ditto-disguises"');
     expect(dittoTicker).not.toContain("useSession");
+    expect(dittoTicker).not.toContain('cache: "no-store"');
+    expect(dittoApi).toContain("max-age=3600");
+    expect(dittoApi).toContain("s-maxage=86400");
     expect(dittoTicker).toContain("<DittoItems disguises={disguises} />");
     expect(dittoTicker).toContain("<DittoItems disguises={disguises} duplicate />");
 

--- a/__tests__/lib/ditto-disguises.test.js
+++ b/__tests__/lib/ditto-disguises.test.js
@@ -1,3 +1,5 @@
+const fs = require("fs")
+const path = require("path")
 const {
   isDittoCacheForSeason,
   normaliseDittoDisguises,
@@ -93,5 +95,19 @@ describe("Ditto disguise helpers", () => {
         new Date("2026-09-08T09:00:00.000Z"),
       ),
     ).toBeNull()
+  })
+
+  it("stores a successful PoGoAPI response in memory before writing the file cache", () => {
+    const serverSource = fs.readFileSync(
+      path.join(process.cwd(), "lib/ditto-disguises-server.ts"),
+      "utf8",
+    )
+    const memoryAssignment = serverSource.indexOf("memoryCache = cache")
+    const diskWrite = serverSource.indexOf("await writeDittoCache(cache)")
+
+    expect(serverSource).toContain("if (memoryCache)")
+    expect(memoryAssignment).toBeGreaterThan(-1)
+    expect(diskWrite).toBeGreaterThan(memoryAssignment)
+    expect(serverSource).toContain("Failed to persist Ditto disguise cache")
   })
 })

--- a/components/events/DittoDisguiseTicker.tsx
+++ b/components/events/DittoDisguiseTicker.tsx
@@ -49,7 +49,6 @@ export default function DittoDisguiseTicker() {
       try {
         const response = await fetch("/api/ditto-disguises", {
           signal: controller.signal,
-          cache: "no-store",
           headers: { Accept: "application/json" },
         });
 

--- a/lib/ditto-disguises-server.ts
+++ b/lib/ditto-disguises-server.ts
@@ -23,6 +23,7 @@ interface StoredDittoCache extends DittoDisguisePayload {
   season: DittoSeason;
 }
 
+let memoryCache: StoredDittoCache | null = null;
 let refreshInFlight: Promise<StoredDittoCache> | null = null;
 
 function requiredString(value: unknown): string | null {
@@ -45,7 +46,21 @@ function normaliseSeason(value: unknown): DittoSeason | null {
     : null;
 }
 
+function cachePayload(cache: StoredDittoCache): DittoDisguisePayload {
+  return {
+    disguises: cache.disguises,
+    season: cache.season,
+    fetchedAt: cache.fetchedAt,
+    isStale: false,
+    warning: cache.warning,
+  };
+}
+
 async function readDittoCache(): Promise<StoredDittoCache | null> {
+  if (memoryCache) {
+    return memoryCache;
+  }
+
   try {
     const source = await fs.readFile(DITTO_CACHE_PATH, "utf8");
     const parsed: unknown = JSON.parse(source);
@@ -68,7 +83,7 @@ async function readDittoCache(): Promise<StoredDittoCache | null> {
       return null;
     }
 
-    return {
+    memoryCache = {
       version: DITTO_CACHE_VERSION,
       fetchedAt,
       season,
@@ -76,6 +91,8 @@ async function readDittoCache(): Promise<StoredDittoCache | null> {
       isStale: false,
       warning: null,
     };
+
+    return memoryCache;
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
 
@@ -129,7 +146,18 @@ async function fetchLatestDisguises(
     warning: null,
   };
 
-  await writeDittoCache(cache);
+  // Put the successful response into memory before attempting the disk write.
+  // This prevents repeat PoGoAPI calls if the runtime can read the project but
+  // cannot persist a cache file for any reason.
+  memoryCache = cache;
+
+  try {
+    await writeDittoCache(cache);
+  } catch (error) {
+    console.error("Failed to persist Ditto disguise cache", error);
+    cache.warning =
+      "Ditto disguises are cached in memory, but the cache file could not be written.";
+  }
 
   return cache;
 }
@@ -187,17 +215,11 @@ export async function getDittoDisguiseData(): Promise<DittoDisguisePayload> {
   }
 
   if (cache && isDittoCacheForSeason(cache.season.eventID, season.eventID)) {
-    return {
-      disguises: cache.disguises,
-      season: cache.season,
-      fetchedAt: cache.fetchedAt,
-      isStale: false,
-      warning: null,
-    };
+    return cachePayload(cache);
   }
 
   try {
-    return await refreshDittoCache(season);
+    return cachePayload(await refreshDittoCache(season));
   } catch (error) {
     if (cache) {
       return staleFallback(cache, error);

--- a/pages/api/ditto-disguises.ts
+++ b/pages/api/ditto-disguises.ts
@@ -18,7 +18,7 @@ export default async function handler(
 
     res.setHeader(
       "Cache-Control",
-      "public, max-age=300, s-maxage=300, stale-while-revalidate=86400",
+      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
     );
 
     return res.status(200).json(payload);


### PR DESCRIPTION
## What changed

- removes the ticker's explicit `cache: "no-store"` request option
- increases the public Ditto API response cache to one hour in browsers and one day in shared caches
- keeps the last successful PoGoAPI response in server memory as well as the JSON file cache
- stores the in-memory cache before attempting the disk write
- continues serving cached data if the cache file cannot be written, instead of downloading PoGoAPI repeatedly
- adds regression tests for the browser, HTTP and server-memory cache behaviour

## Root cause

The ticker explicitly bypassed the HTTP cache on every request. The server also treated a disk-cache write failure as a failed refresh, leaving no usable cache and allowing repeated upstream requests.

## Validation

The repository Validate workflow will run audits, ESLint, Jest and the production build.