### PR TITLE
Change Ditto cache cadence to daily

### DIFF
--- a/__tests__/components/tickers.test.js
+++ b/__tests__/components/tickers.test.js
@@ -33,11 +33,12 @@ describe("ticker regression wiring", () => {
     expect(raidTicker).toContain("display: none;");
   });
 
-  it("keeps the Ditto ticker public, cached and between raids and new gyms", () => {
+  it("keeps the Ditto ticker public, daily cached and between raids and new gyms", () => {
     expect(dittoTicker).toContain('fetch("/api/ditto-disguises"');
     expect(dittoTicker).not.toContain("useSession");
     expect(dittoTicker).not.toContain('cache: "no-store"');
-    expect(dittoApi).toContain("max-age=3600");
+    expect(dittoTicker).toContain("const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;");
+    expect(dittoApi).toContain("max-age=86400");
     expect(dittoApi).toContain("s-maxage=86400");
     expect(dittoTicker).toContain("<DittoItems disguises={disguises} />");
     expect(dittoTicker).toContain("<DittoItems disguises={disguises} duplicate />");

--- a/components/events/DittoDisguiseTicker.tsx
+++ b/components/events/DittoDisguiseTicker.tsx
@@ -7,7 +7,7 @@ import type {
 
 type DittoTickerStatus = "loading" | "ready" | "error";
 
-const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 function DittoItems({
   disguises,

--- a/pages/api/ditto-disguises.ts
+++ b/pages/api/ditto-disguises.ts
@@ -18,7 +18,7 @@ export default async function handler(
 
     res.setHeader(
       "Cache-Control",
-      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800",
     );
 
     return res.status(200).json(payload);


### PR DESCRIPTION
## What changed

- changes the Ditto ticker refresh timer from one hour to 24 hours
- changes the browser cache lifetime for `/api/ditto-disguises` from one hour to 24 hours
- keeps the shared-cache lifetime at 24 hours
- updates regression coverage for the daily cadence

## Validation

The repository Validate workflow will run dependency audits, ESLint, Jest and the production build.