### PR TITLE
Use PoGoAPI hash manifest for cached datasets

### DIFF
--- a/__tests__/lib/ditto-disguises.test.js
+++ b/__tests__/lib/ditto-disguises.test.js
@@ -1,12 +1,9 @@
 const fs = require("fs")
 const path = require("path")
 const {
-  isDittoCacheForSeason,
+  isDittoCacheForHash,
   normaliseDittoDisguises,
 } = require("../../lib/ditto-disguises")
-const {
-  selectCurrentPokemonGoSeason,
-} = require("../../lib/season-server")
 
 describe("Ditto disguise helpers", () => {
   it("normalises, sorts and de-duplicates the PoGoAPI object payload", () => {
@@ -23,78 +20,28 @@ describe("Ditto disguise helpers", () => {
     ])
   })
 
-  it("keeps the cache while the ScrapedDuck season ID is unchanged", () => {
-    expect(
-      isDittoCacheForSeason(
-        "season-23-forever-forward",
-        "season-23-forever-forward",
-      ),
-    ).toBe(true)
-    expect(
-      isDittoCacheForSeason(
-        "season-23-forever-forward",
-        "season-24-next-season",
-      ),
-    ).toBe(false)
+  it("keeps the cached dataset only while its PoGoAPI hash is unchanged", () => {
+    expect(isDittoCacheForHash("same-hash", "same-hash")).toBe(true)
+    expect(isDittoCacheForHash("old-hash", "new-hash")).toBe(false)
+    expect(isDittoCacheForHash(null, "new-hash")).toBe(false)
   })
 
-  it("selects the active ScrapedDuck season using London-local timestamps", () => {
-    const events = [
-      {
-        eventID: "season-old",
-        name: "Old Season",
-        eventType: "season",
-        heading: "Season",
-        link: null,
-        image: null,
-        start: "2026-03-01T10:00:00.000",
-        end: "2026-06-02T10:00:00.000",
-      },
-      {
-        eventID: "season-23-forever-forward",
-        name: "Forever Forward",
-        eventType: "season",
-        heading: "Season",
-        link: null,
-        image: null,
-        start: "2026-06-02T10:00:00.000",
-        end: "2026-09-08T10:00:00.000",
-      },
-    ]
+  it("uses the shared daily hash manifest instead of ScrapedDuck seasons", () => {
+    const serverSource = fs.readFileSync(
+      path.join(process.cwd(), "lib/ditto-disguises-server.ts"),
+      "utf8",
+    )
 
-    expect(
-      selectCurrentPokemonGoSeason(
-        events,
-        new Date("2026-07-31T15:00:00.000Z"),
-      ),
-    ).toEqual({
-      eventID: "season-23-forever-forward",
-      name: "Forever Forward",
-      start: "2026-06-02T10:00:00.000",
-      end: "2026-09-08T10:00:00.000",
-    })
-  })
-
-  it("stops using a season at its exact ScrapedDuck end time", () => {
-    const events = [
-      {
-        eventID: "season-23-forever-forward",
-        name: "Forever Forward",
-        eventType: "season",
-        heading: "Season",
-        link: null,
-        image: null,
-        start: "2026-06-02T10:00:00.000",
-        end: "2026-09-08T10:00:00.000",
-      },
-    ]
-
-    expect(
-      selectCurrentPokemonGoSeason(
-        events,
-        new Date("2026-09-08T09:00:00.000Z"),
-      ),
-    ).toBeNull()
+    expect(serverSource).toContain(
+      "getPogoApiFileHash(DITTO_API_FILENAME)",
+    )
+    expect(serverSource).toContain(
+      'const DITTO_API_FILENAME = "possible_ditto_pokemon.json"',
+    )
+    expect(serverSource).toContain("isDittoCacheForHash")
+    expect(serverSource).toContain("!cache.sourceHash")
+    expect(serverSource).not.toContain("getCurrentPokemonGoSeason")
+    expect(serverSource).not.toContain("ScrapedDuck did not provide")
   })
 
   it("stores a successful PoGoAPI response in memory before writing the file cache", () => {

--- a/__tests__/lib/pogoApiHashCache.test.js
+++ b/__tests__/lib/pogoApiHashCache.test.js
@@ -1,0 +1,75 @@
+const {
+  HASH_CACHE_TTL_MS,
+  isHashCacheFresh,
+  normaliseHashManifest,
+  selectPreferredHash,
+} = require("../../lib/pogoApiHashCache");
+
+function hashEntry(filename, index) {
+  return {
+    api_filename: filename,
+    full_path: `/api/v1/${filename}`,
+    hash_md5: `md5-${index}`,
+    hash_sha1: `sha1-${index}`,
+    hash_sha256: `sha256-${index}`,
+  };
+}
+
+describe("PoGoAPI hash manifest helpers", () => {
+  it("stores every valid API hash entry from the manifest", () => {
+    const payload = Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => {
+        const filename = `api-${index}.json`;
+        return [filename, hashEntry(filename, index)];
+      }),
+    );
+
+    const manifest = normaliseHashManifest(payload);
+
+    expect(Object.keys(manifest)).toHaveLength(12);
+    expect(manifest["api-4.json"]).toEqual(hashEntry("api-4.json", 4));
+  });
+
+  it("prefers SHA-256, then SHA-1, then MD5", () => {
+    expect(
+      selectPreferredHash({
+        hash_sha256: "sha256",
+        hash_sha1: "sha1",
+        hash_md5: "md5",
+      }),
+    ).toBe("sha256");
+    expect(
+      selectPreferredHash({
+        hash_sha256: null,
+        hash_sha1: "sha1",
+        hash_md5: "md5",
+      }),
+    ).toBe("sha1");
+    expect(
+      selectPreferredHash({
+        hash_sha256: null,
+        hash_sha1: null,
+        hash_md5: "md5",
+      }),
+    ).toBe("md5");
+  });
+
+  it("checks the manifest once per day", () => {
+    const now = Date.parse("2026-07-31T12:00:00.000Z");
+
+    expect(
+      isHashCacheFresh(
+        { checkedAt: new Date(now - HASH_CACHE_TTL_MS + 1_000).toISOString() },
+        HASH_CACHE_TTL_MS,
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      isHashCacheFresh(
+        { checkedAt: new Date(now - HASH_CACHE_TTL_MS - 1_000).toISOString() },
+        HASH_CACHE_TTL_MS,
+        now,
+      ),
+    ).toBe(false);
+  });
+});

--- a/__tests__/lib/releasedPokemonCache.test.js
+++ b/__tests__/lib/releasedPokemonCache.test.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+const path = require("path");
 const {
   CACHE_TTL_MS,
   extractReleasedDexNumbers,
@@ -50,5 +52,15 @@ describe("released Pokémon cache helpers", () => {
         now
       )
     ).toBe(false);
+  });
+
+  it("uses the shared PoGoAPI hash manifest", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "lib/releasedPokemonCache.js"),
+      "utf8",
+    );
+
+    expect(source).toContain("getPogoApiFileHash(RELEASED_POKEMON_FILENAME)");
+    expect(source).not.toContain('const API_HASHES_URL =');
   });
 });

--- a/__tests__/lib/releasedPokemonCache.test.js
+++ b/__tests__/lib/releasedPokemonCache.test.js
@@ -37,10 +37,11 @@ describe("released Pokémon cache helpers", () => {
     expect(filterReleasedDexNumbers([1, 2, 3, 999], [1, 3, 4])).toEqual([1, 3]);
   });
 
-  it("treats the cache as fresh for seven days", () => {
+  it("checks the released Pokémon hash once per day", () => {
     const now = Date.parse("2026-07-31T12:00:00.000Z");
     const cache = { checkedAt: new Date(now - CACHE_TTL_MS + 1_000).toISOString() };
 
+    expect(CACHE_TTL_MS).toBe(24 * 60 * 60 * 1000);
     expect(isCacheFresh(cache, CACHE_TTL_MS, now)).toBe(true);
     expect(
       isCacheFresh(

--- a/lib/ditto-disguises-server.ts
+++ b/lib/ditto-disguises-server.ts
@@ -1,58 +1,95 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  isDittoCacheForSeason,
+  isDittoCacheForHash,
   normaliseDittoDisguises,
+  type DittoDisguise,
   type DittoDisguisePayload,
-  type DittoSeason,
 } from "./ditto-disguises";
 import {
-  getCurrentPokemonGoSeason,
-  type PokemonGoSeasonBoundary,
-} from "./season-server";
+  HASH_CACHE_TTL_MS,
+  getPogoApiFileHash,
+  type PogoApiFileHash,
+} from "./pogoApiHashCache";
 
+const DITTO_API_FILENAME = "possible_ditto_pokemon.json";
 const DITTO_FEED_URL =
   "https://pogoapi.net/api/v1/possible_ditto_pokemon.json";
-const DITTO_CACHE_VERSION = 1;
+const DITTO_CACHE_VERSION = 2;
+const REQUEST_TIMEOUT_MS = 15_000;
 const DITTO_CACHE_PATH =
   process.env.DITTO_CACHE_PATH?.trim() ||
   path.join(process.cwd(), "data", "ditto-disguises-cache.json");
 
-interface StoredDittoCache extends DittoDisguisePayload {
+interface StoredDittoCache {
   version: number;
-  season: DittoSeason;
+  checkedAt: string;
+  fetchedAt: string;
+  sourceHash: string | null;
+  disguises: DittoDisguise[];
+  warning: string | null;
 }
 
 let memoryCache: StoredDittoCache | null = null;
 let refreshInFlight: Promise<StoredDittoCache> | null = null;
 
-function requiredString(value: unknown): string | null {
+function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function normaliseSeason(value: unknown): DittoSeason | null {
-  if (!value || typeof value !== "object") {
+function normaliseIsoDate(value: unknown): string | null {
+  const source = optionalString(value);
+  const timestamp = source ? Date.parse(source) : Number.NaN;
+
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function isCacheFresh(
+  cache: StoredDittoCache | null,
+  now: number = Date.now(),
+): boolean {
+  if (!cache?.checkedAt) {
+    return false;
+  }
+
+  const checkedAt = Date.parse(cache.checkedAt);
+  return Number.isFinite(checkedAt) && now - checkedAt < HASH_CACHE_TTL_MS;
+}
+
+function cachePayload(
+  cache: StoredDittoCache,
+  isStale: boolean = false,
+): DittoDisguisePayload {
+  return {
+    disguises: cache.disguises,
+    season: null,
+    fetchedAt: cache.fetchedAt,
+    isStale,
+    warning: cache.warning,
+  };
+}
+
+function normaliseStoredCache(value: unknown): StoredDittoCache | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
 
   const candidate = value as Record<string, unknown>;
-  const eventID = requiredString(candidate.eventID);
-  const name = requiredString(candidate.name);
-  const start = requiredString(candidate.start);
-  const end = requiredString(candidate.end);
+  const fetchedAt = normaliseIsoDate(candidate.fetchedAt);
+  const checkedAt = normaliseIsoDate(candidate.checkedAt) ?? fetchedAt;
+  const disguises = normaliseDittoDisguises(candidate.disguises);
 
-  return eventID && name && start && end
-    ? { eventID, name, start, end }
-    : null;
-}
+  if (!fetchedAt || !checkedAt || disguises.length === 0) {
+    return null;
+  }
 
-function cachePayload(cache: StoredDittoCache): DittoDisguisePayload {
   return {
-    disguises: cache.disguises,
-    season: cache.season,
-    fetchedAt: cache.fetchedAt,
-    isStale: false,
-    warning: cache.warning,
+    version: DITTO_CACHE_VERSION,
+    checkedAt,
+    fetchedAt,
+    sourceHash: optionalString(candidate.sourceHash),
+    disguises,
+    warning: optionalString(candidate.warning),
   };
 }
 
@@ -63,35 +100,7 @@ async function readDittoCache(): Promise<StoredDittoCache | null> {
 
   try {
     const source = await fs.readFile(DITTO_CACHE_PATH, "utf8");
-    const parsed: unknown = JSON.parse(source);
-
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-
-    const candidate = parsed as Record<string, unknown>;
-    const fetchedAt = requiredString(candidate.fetchedAt);
-    const season = normaliseSeason(candidate.season);
-    const disguises = normaliseDittoDisguises(candidate.disguises);
-
-    if (
-      candidate.version !== DITTO_CACHE_VERSION ||
-      !fetchedAt ||
-      !season ||
-      disguises.length === 0
-    ) {
-      return null;
-    }
-
-    memoryCache = {
-      version: DITTO_CACHE_VERSION,
-      fetchedAt,
-      season,
-      disguises,
-      isStale: false,
-      warning: null,
-    };
-
+    memoryCache = normaliseStoredCache(JSON.parse(source));
     return memoryCache;
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
@@ -111,44 +120,20 @@ async function writeDittoCache(cache: StoredDittoCache): Promise<void> {
   await fs.mkdir(directory, { recursive: true });
 
   try {
-    await fs.writeFile(temporaryPath, `${JSON.stringify(cache)}\n`, "utf8");
+    await fs.writeFile(
+      temporaryPath,
+      `${JSON.stringify(cache, null, 2)}\n`,
+      "utf8",
+    );
     await fs.rename(temporaryPath, DITTO_CACHE_PATH);
   } finally {
     await fs.unlink(temporaryPath).catch(() => undefined);
   }
 }
 
-async function fetchLatestDisguises(
-  season: PokemonGoSeasonBoundary,
+async function persistDittoCache(
+  cache: StoredDittoCache,
 ): Promise<StoredDittoCache> {
-  const response = await fetch(DITTO_FEED_URL, {
-    headers: { Accept: "application/json" },
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `PoGoAPI Ditto feed returned ${response.status} ${response.statusText}`,
-    );
-  }
-
-  const disguises = normaliseDittoDisguises(await response.json());
-
-  if (disguises.length === 0) {
-    throw new Error("PoGoAPI Ditto feed did not contain any disguises");
-  }
-
-  const cache: StoredDittoCache = {
-    version: DITTO_CACHE_VERSION,
-    fetchedAt: new Date().toISOString(),
-    season,
-    disguises,
-    isStale: false,
-    warning: null,
-  };
-
-  // Put the successful response into memory before attempting the disk write.
-  // This prevents repeat PoGoAPI calls if the runtime can read the project but
-  // cannot persist a cache file for any reason.
   memoryCache = cache;
 
   try {
@@ -162,11 +147,66 @@ async function fetchLatestDisguises(
   return cache;
 }
 
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "LEIGHPOGO ditto-disguise-cache",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `PoGoAPI Ditto feed returned ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function dataUrl(hashEntry: PogoApiFileHash | null): string {
+  return hashEntry?.fullPath
+    ? new URL(hashEntry.fullPath, "https://pogoapi.net").toString()
+    : DITTO_FEED_URL;
+}
+
+async function fetchLatestDisguises(
+  hashEntry: PogoApiFileHash | null,
+): Promise<StoredDittoCache> {
+  const disguises = normaliseDittoDisguises(
+    await fetchJson(dataUrl(hashEntry)),
+  );
+
+  if (disguises.length === 0) {
+    throw new Error("PoGoAPI Ditto feed did not contain any disguises");
+  }
+
+  const now = new Date().toISOString();
+  const cache: StoredDittoCache = {
+    version: DITTO_CACHE_VERSION,
+    checkedAt: now,
+    fetchedAt: now,
+    sourceHash: hashEntry?.hash ?? null,
+    disguises,
+    warning: hashEntry?.warning ?? null,
+  };
+
+  return persistDittoCache(cache);
+}
+
 async function refreshDittoCache(
-  season: PokemonGoSeasonBoundary,
+  hashEntry: PogoApiFileHash | null,
 ): Promise<StoredDittoCache> {
   if (!refreshInFlight) {
-    refreshInFlight = fetchLatestDisguises(season).finally(() => {
+    refreshInFlight = fetchLatestDisguises(hashEntry).finally(() => {
       refreshInFlight = null;
     });
   }
@@ -174,15 +214,25 @@ async function refreshDittoCache(
   return refreshInFlight;
 }
 
+async function markCacheChecked(
+  cache: StoredDittoCache,
+  hashEntry: PogoApiFileHash,
+): Promise<StoredDittoCache> {
+  return persistDittoCache({
+    ...cache,
+    version: DITTO_CACHE_VERSION,
+    checkedAt: new Date().toISOString(),
+    sourceHash: hashEntry.hash,
+    warning: hashEntry.warning,
+  });
+}
+
 function staleFallback(
   cache: StoredDittoCache,
   error: unknown,
 ): DittoDisguisePayload {
   return {
-    disguises: cache.disguises,
-    season: cache.season,
-    fetchedAt: cache.fetchedAt,
-    isStale: true,
+    ...cachePayload(cache, true),
     warning:
       error instanceof Error
         ? `The Ditto disguise refresh failed: ${error.message}`
@@ -192,34 +242,36 @@ function staleFallback(
 
 export async function getDittoDisguiseData(): Promise<DittoDisguisePayload> {
   const cache = await readDittoCache();
-  let season: PokemonGoSeasonBoundary | null;
+
+  if (cache && isCacheFresh(cache)) {
+    return cachePayload(cache);
+  }
+
+  let hashEntry: PogoApiFileHash | null = null;
 
   try {
-    season = await getCurrentPokemonGoSeason();
+    hashEntry = await getPogoApiFileHash(DITTO_API_FILENAME);
   } catch (error) {
     if (cache) {
       return staleFallback(cache, error);
     }
 
-    throw error;
+    console.warn(
+      "Unable to check the PoGoAPI hash manifest; downloading the initial Ditto list directly",
+      error,
+    );
   }
 
-  if (!season) {
-    const error = new Error("ScrapedDuck did not provide an active season");
-
-    if (cache) {
-      return staleFallback(cache, error);
-    }
-
-    throw error;
-  }
-
-  if (cache && isDittoCacheForSeason(cache.season.eventID, season.eventID)) {
-    return cachePayload(cache);
+  if (
+    cache &&
+    hashEntry &&
+    isDittoCacheForHash(cache.sourceHash, hashEntry.hash)
+  ) {
+    return cachePayload(await markCacheChecked(cache, hashEntry));
   }
 
   try {
-    return cachePayload(await refreshDittoCache(season));
+    return cachePayload(await refreshDittoCache(hashEntry));
   } catch (error) {
     if (cache) {
       return staleFallback(cache, error);

--- a/lib/ditto-disguises-server.ts
+++ b/lib/ditto-disguises-server.ts
@@ -48,7 +48,7 @@ function isCacheFresh(
   cache: StoredDittoCache | null,
   now: number = Date.now(),
 ): boolean {
-  if (!cache?.checkedAt) {
+  if (!cache?.checkedAt || !cache.sourceHash) {
     return false;
   }
 

--- a/lib/ditto-disguises.ts
+++ b/lib/ditto-disguises.ts
@@ -49,13 +49,9 @@ export function normaliseDittoDisguises(payload: unknown): DittoDisguise[] {
   );
 }
 
-export function isDittoCacheForSeason(
-  cachedSeasonID: string | null | undefined,
-  currentSeasonID: string | null | undefined,
+export function isDittoCacheForHash(
+  cachedHash: string | null | undefined,
+  currentHash: string | null | undefined,
 ): boolean {
-  return Boolean(
-    cachedSeasonID &&
-      currentSeasonID &&
-      cachedSeasonID === currentSeasonID,
-  );
+  return Boolean(cachedHash && currentHash && cachedHash === currentHash);
 }

--- a/lib/pogoApiHashCache.d.ts
+++ b/lib/pogoApiHashCache.d.ts
@@ -1,0 +1,57 @@
+export interface PogoApiHashEntry {
+  api_filename: string;
+  full_path: string;
+  hash_md5: string | null;
+  hash_sha1: string | null;
+  hash_sha256: string | null;
+}
+
+export interface PogoApiHashManifest {
+  version: number;
+  checkedAt: string;
+  hashes: Record<string, PogoApiHashEntry>;
+  stale: boolean;
+  warning: string | null;
+}
+
+export interface PogoApiFileHash {
+  filename: string;
+  fullPath: string;
+  hash: string;
+  checkedAt: string;
+  stale: boolean;
+  warning: string | null;
+}
+
+export interface PogoApiHashOptions {
+  allowStale?: boolean;
+  cachePath?: string;
+  forceRefresh?: boolean;
+  strictWrite?: boolean;
+}
+
+export const API_HASHES_URL: string;
+export const HASH_CACHE_TTL_MS: number;
+
+export function getPogoApiFileHash(
+  filename: string,
+  options?: PogoApiHashOptions,
+): Promise<PogoApiFileHash>;
+
+export function getPogoApiHashManifest(
+  options?: PogoApiHashOptions,
+): Promise<PogoApiHashManifest>;
+
+export function isHashCacheFresh(
+  cache: { checkedAt?: string | null } | null | undefined,
+  maxAgeMs?: number,
+  now?: number,
+): boolean;
+
+export function normaliseHashManifest(
+  payload: unknown,
+): Record<string, PogoApiHashEntry>;
+
+export function selectPreferredHash(
+  entry: Partial<PogoApiHashEntry> | null | undefined,
+): string | null;

--- a/lib/pogoApiHashCache.js
+++ b/lib/pogoApiHashCache.js
@@ -1,0 +1,229 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+const API_HASHES_URL = "https://pogoapi.net/api/v1/api_hashes.json";
+const HASH_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const HASH_CACHE_VERSION = 1;
+const MIN_EXPECTED_HASH_ENTRIES = 10;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const memoryCaches = new Map();
+const refreshPromises = new Map();
+
+const runtimeCachePath = () =>
+  process.env.POGOAPI_HASH_CACHE_PATH ||
+  path.join(process.cwd(), "data", ".cache", "pogoapi-api-hashes.json");
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normaliseHashEntry(filename, value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const apiFilename = optionalString(value.api_filename) || optionalString(filename);
+  const fullPath = optionalString(value.full_path);
+  const hashMd5 = optionalString(value.hash_md5);
+  const hashSha1 = optionalString(value.hash_sha1);
+  const hashSha256 = optionalString(value.hash_sha256);
+
+  if (!apiFilename || !fullPath || (!hashSha256 && !hashSha1 && !hashMd5)) {
+    return null;
+  }
+
+  return {
+    api_filename: apiFilename,
+    full_path: fullPath,
+    hash_md5: hashMd5,
+    hash_sha1: hashSha1,
+    hash_sha256: hashSha256,
+  };
+}
+
+function normaliseHashManifest(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("PoGoAPI returned an invalid API hash manifest.");
+  }
+
+  const hashes = Object.fromEntries(
+    Object.entries(payload)
+      .map(([filename, value]) => [filename, normaliseHashEntry(filename, value)])
+      .filter(([, value]) => value !== null)
+  );
+
+  if (Object.keys(hashes).length < MIN_EXPECTED_HASH_ENTRIES) {
+    throw new Error("PoGoAPI API hash manifest was unexpectedly small.");
+  }
+
+  return hashes;
+}
+
+function selectPreferredHash(entry) {
+  if (!entry || typeof entry !== "object") return null;
+
+  return entry.hash_sha256 || entry.hash_sha1 || entry.hash_md5 || null;
+}
+
+function isHashCacheFresh(cache, maxAgeMs = HASH_CACHE_TTL_MS, now = Date.now()) {
+  if (!cache?.checkedAt) return false;
+
+  const checkedAt = Date.parse(cache.checkedAt);
+  return Number.isFinite(checkedAt) && now - checkedAt < maxAgeMs;
+}
+
+function validateStoredCache(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (value.version !== HASH_CACHE_VERSION) return null;
+
+  const checkedAt = optionalString(value.checkedAt);
+  if (!checkedAt || !Number.isFinite(Date.parse(checkedAt))) return null;
+
+  try {
+    return {
+      version: HASH_CACHE_VERSION,
+      checkedAt: new Date(checkedAt).toISOString(),
+      hashes: normaliseHashManifest(value.hashes),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readJson(filePath) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT" || error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
+async function readCache(filePath) {
+  const memoryCache = memoryCaches.get(filePath);
+  if (memoryCache) return memoryCache;
+
+  const cache = validateStoredCache(await readJson(filePath));
+  if (cache) memoryCaches.set(filePath, cache);
+  return cache;
+}
+
+async function fetchJson(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "LEIGHPOGO pogoapi-hash-cache",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`PoGoAPI hash request failed with status ${response.status}.`);
+    }
+
+    return response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function writeCache(filePath, cache, strictWrite) {
+  const directory = path.dirname(filePath);
+  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+
+  try {
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(temporaryPath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+    await fs.rename(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      await fs.unlink(temporaryPath);
+    } catch {}
+
+    if (strictWrite) throw error;
+    console.error("Unable to persist the PoGoAPI hash manifest cache", error);
+  }
+}
+
+async function refreshHashManifest(filePath, strictWrite) {
+  const cache = {
+    version: HASH_CACHE_VERSION,
+    checkedAt: new Date().toISOString(),
+    hashes: normaliseHashManifest(await fetchJson(API_HASHES_URL)),
+  };
+
+  memoryCaches.set(filePath, cache);
+  await writeCache(filePath, cache, strictWrite);
+  return cache;
+}
+
+async function getPogoApiHashManifest(options = {}) {
+  const cachePath = options.cachePath || runtimeCachePath();
+  const allowStale = options.allowStale !== false;
+  const forceRefresh = options.forceRefresh === true;
+  const strictWrite = options.strictWrite === true;
+  const existingCache = await readCache(cachePath);
+
+  if (!forceRefresh && isHashCacheFresh(existingCache)) {
+    return { ...existingCache, stale: false, warning: null };
+  }
+
+  if (!refreshPromises.has(cachePath)) {
+    refreshPromises.set(
+      cachePath,
+      refreshHashManifest(cachePath, strictWrite).finally(() => {
+        refreshPromises.delete(cachePath);
+      })
+    );
+  }
+
+  try {
+    const refreshedCache = await refreshPromises.get(cachePath);
+    return { ...refreshedCache, stale: false, warning: null };
+  } catch (error) {
+    if (allowStale && existingCache) {
+      return {
+        ...existingCache,
+        stale: true,
+        warning:
+          error instanceof Error
+            ? `The PoGoAPI hash manifest refresh failed: ${error.message}`
+            : "The PoGoAPI hash manifest refresh failed.",
+      };
+    }
+
+    throw error;
+  }
+}
+
+async function getPogoApiFileHash(filename, options = {}) {
+  const manifest = await getPogoApiHashManifest(options);
+  const entry = manifest.hashes[filename];
+  const hash = selectPreferredHash(entry);
+
+  if (!entry || !hash) {
+    throw new Error(`PoGoAPI hash manifest does not contain ${filename}.`);
+  }
+
+  return {
+    filename,
+    fullPath: entry.full_path,
+    hash,
+    checkedAt: manifest.checkedAt,
+    stale: manifest.stale,
+    warning: manifest.warning,
+  };
+}
+
+module.exports = {
+  API_HASHES_URL,
+  HASH_CACHE_TTL_MS,
+  getPogoApiFileHash,
+  getPogoApiHashManifest,
+  isHashCacheFresh,
+  normaliseHashManifest,
+  selectPreferredHash,
+};

--- a/lib/releasedPokemonCache.js
+++ b/lib/releasedPokemonCache.js
@@ -1,9 +1,14 @@
 const fs = require("fs/promises");
 const path = require("path");
+const {
+  HASH_CACHE_TTL_MS,
+  getPogoApiFileHash,
+} = require("./pogoApiHashCache");
 
-const RELEASED_POKEMON_URL = "https://pogoapi.net/api/v1/released_pokemon.json";
-const API_HASHES_URL = "https://pogoapi.net/api/v1/api_hashes.json";
-const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const RELEASED_POKEMON_FILENAME = "released_pokemon.json";
+const RELEASED_POKEMON_URL =
+  "https://pogoapi.net/api/v1/released_pokemon.json";
+const CACHE_TTL_MS = HASH_CACHE_TTL_MS;
 const MIN_EXPECTED_RELEASED_POKEMON = 100;
 const REQUEST_TIMEOUT_MS = 15_000;
 
@@ -68,7 +73,9 @@ function isCacheFresh(cache, maxAgeMs = CACHE_TTL_MS, now = Date.now()) {
 
 function filterReleasedDexNumbers(values, releasedDexNumbers) {
   const releasedSet = new Set(normaliseDexNumbers(releasedDexNumbers));
-  return normaliseDexNumbers(values).filter((dexNumber) => releasedSet.has(dexNumber));
+  return normaliseDexNumbers(values).filter((dexNumber) =>
+    releasedSet.has(dexNumber)
+  );
 }
 
 async function readJson(filePath) {
@@ -123,25 +130,17 @@ async function fetchJson(url) {
   }
 }
 
-async function fetchReleasedPokemonHash() {
-  const hashes = await fetchJson(API_HASHES_URL);
-  const releasedHash = hashes?.["released_pokemon.json"];
-
-  return (
-    releasedHash?.hash_sha256 ||
-    releasedHash?.hash_sha1 ||
-    releasedHash?.hash_md5 ||
-    null
-  );
-}
-
 async function writeCache(filePath, cache, strictWrite) {
   const directory = path.dirname(filePath);
   const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
 
   try {
     await fs.mkdir(directory, { recursive: true });
-    await fs.writeFile(temporaryPath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+    await fs.writeFile(
+      temporaryPath,
+      `${JSON.stringify(cache, null, 2)}\n`,
+      "utf8"
+    );
     await fs.rename(temporaryPath, filePath);
   } catch (error) {
     try {
@@ -156,11 +155,24 @@ async function writeCache(filePath, cache, strictWrite) {
 async function refreshReleasedPokemonData(existingCache, options) {
   const checkedAt = new Date().toISOString();
   let sourceHash = null;
+  let releasedPokemonUrl = RELEASED_POKEMON_URL;
 
   try {
-    sourceHash = await fetchReleasedPokemonHash();
+    const hashEntry = await getPogoApiFileHash(RELEASED_POKEMON_FILENAME);
+    sourceHash = hashEntry.hash;
+    releasedPokemonUrl = new URL(
+      hashEntry.fullPath,
+      "https://pogoapi.net"
+    ).toString();
   } catch (error) {
-    console.warn("Unable to check the PogoAPI release-list hash; downloading the list directly", error);
+    if (existingCache) {
+      throw error;
+    }
+
+    console.warn(
+      "Unable to check the PoGoAPI hash manifest; downloading the initial released Pokémon list directly",
+      error
+    );
   }
 
   if (
@@ -179,7 +191,7 @@ async function refreshReleasedPokemonData(existingCache, options) {
     return unchangedCache;
   }
 
-  const releasedPokemon = await fetchJson(RELEASED_POKEMON_URL);
+  const releasedPokemon = await fetchJson(releasedPokemonUrl);
   const refreshedCache = {
     checkedAt,
     sourceHash,
@@ -210,7 +222,10 @@ async function getReleasedPokemonData(options = {}) {
   }
 
   if (!refreshPromise) {
-    refreshPromise = refreshReleasedPokemonData(existingCache, resolvedOptions).finally(() => {
+    refreshPromise = refreshReleasedPokemonData(
+      existingCache,
+      resolvedOptions
+    ).finally(() => {
       refreshPromise = null;
     });
   }
@@ -220,7 +235,10 @@ async function getReleasedPokemonData(options = {}) {
     return { ...refreshedCache, stale: false };
   } catch (error) {
     if (resolvedOptions.allowStale && existingCache) {
-      console.error("Unable to refresh released Pokémon; using the last valid cache", error);
+      console.error(
+        "Unable to refresh released Pokémon; using the last valid cache",
+        error
+      );
       return { ...existingCache, stale: true };
     }
 


### PR DESCRIPTION
## What changed

- adds a shared cache for PoGoAPI's complete `api_hashes.json` manifest
- stores every API filename, path, MD5, SHA-1 and SHA-256 entry locally
- refreshes the hash manifest once every 24 hours
- checks the two PoGoAPI datasets currently used by the app against that manifest:
  - `released_pokemon.json`
  - `possible_ditto_pokemon.json`
- downloads an individual dataset only when its preferred hash changes or no hashed cache exists
- removes Ditto's dependency on ScrapedDuck season detection before fetching PoGoAPI
- treats old season-based Ditto caches as unchecked so they refresh immediately after deployment
- retains stale valid datasets if the hash manifest or an individual API is temporarily unavailable
- adds regression tests for full-manifest storage, hash preference, daily checks and both consumers

## Cache files

- full hash manifest: `data/.cache/pogoapi-api-hashes.json`
- released Pokémon: existing `data/.cache/released-pokemon.json`
- Ditto disguises: existing `data/ditto-disguises-cache.json`, upgraded to include `checkedAt` and `sourceHash`

## Validation

The repository Validate workflow will run dependency audits, ESLint, Jest and the production build.