### PR TITLE
Notify both sides of wishlist matches

### DIFF
--- a/__tests__/lib/trade-notifications.test.js
+++ b/__tests__/lib/trade-notifications.test.js
@@ -1,12 +1,30 @@
 process.env.DATABASE_URL =
   process.env.DATABASE_URL || "file:trade-notification-tests?mode=memory&cache=shared"
 
+jest.mock("../../lib/prisma", () => ({
+  wantedTrade: {
+    findMany: jest.fn(),
+  },
+  tradeNotification: {
+    upsert: jest.fn(),
+  },
+}))
+
+const prisma = require("../../lib/prisma")
 const {
+  syncWantedTradeNotificationsForListing,
   tradeModifierLabels,
   wantedTradeMatchesOffer,
 } = require("../../lib/tradeNotifications")
 
 describe("wishlist trade matching", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prisma.tradeNotification.upsert.mockImplementation(({ create }) =>
+      Promise.resolve(create),
+    )
+  })
+
   it("matches names case-insensitively and allows unspecified modifiers", () => {
     expect(wantedTradeMatchesOffer(
       { pokemonName: "Pikachu" },
@@ -51,5 +69,80 @@ describe("wishlist trade matching", () => {
       xxl: true,
       background: true,
     })).toEqual(["Shiny", "Lucky", "XXL", "Special background"])
+  })
+
+  it("notifies each wishlist owner and the listing owner", async () => {
+    prisma.wantedTrade.findMany.mockResolvedValueOnce([
+      {
+        ownerId: 2,
+        owner: { ign: "Misty" },
+        pokemonName: "Pikachu",
+        shiny: true,
+      },
+      {
+        ownerId: 3,
+        owner: { ign: "Brock" },
+        pokemonName: "Pikachu",
+      },
+    ])
+
+    await syncWantedTradeNotificationsForListing({
+      id: 17,
+      ownerId: 1,
+      items: [
+        {
+          direction: "OFFER",
+          pokemonName: "Pikachu",
+          shiny: true,
+          lucky: true,
+        },
+      ],
+    })
+
+    expect(prisma.wantedTrade.findMany).toHaveBeenCalledWith({
+      where: { ownerId: { not: 1 } },
+      include: { owner: { select: { ign: true } } },
+    })
+    expect(prisma.tradeNotification.upsert).toHaveBeenCalledTimes(3)
+
+    const notifications = prisma.tradeNotification.upsert.mock.calls.map(
+      ([call]) => call.create,
+    )
+
+    expect(notifications).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ownerId: 2,
+        listingId: 17,
+        type: "WISHLIST_MATCH",
+        pokemonName: "Pikachu",
+      }),
+      expect.objectContaining({
+        ownerId: 3,
+        listingId: 17,
+        type: "WISHLIST_MATCH",
+        pokemonName: "Pikachu",
+      }),
+      expect.objectContaining({
+        ownerId: 1,
+        listingId: 17,
+        type: "LISTING_MATCH",
+        pokemonName: "Pikachu",
+        matchedTrainerSummary: "Misty and Brock",
+        matchedTrainerCount: 2,
+      }),
+    ]))
+  })
+
+  it("does not notify the listing owner when nobody else matches", async () => {
+    prisma.wantedTrade.findMany.mockResolvedValueOnce([])
+
+    const notifications = await syncWantedTradeNotificationsForListing({
+      id: 18,
+      ownerId: 1,
+      items: [{ direction: "OFFER", pokemonName: "Eevee" }],
+    })
+
+    expect(notifications).toEqual([])
+    expect(prisma.tradeNotification.upsert).not.toHaveBeenCalled()
   })
 })

--- a/lib/tradeNotifications.js
+++ b/lib/tradeNotifications.js
@@ -13,6 +13,21 @@ const modifierDefinitions = [
 
 const normalizedName = (value) => String(value ?? "").trim().toLowerCase()
 
+const summarizeTrainerNames = (names) => {
+  const uniqueNames = Array.from(
+    new Set(names.map((name) => String(name ?? "").trim()).filter(Boolean)),
+  )
+
+  if (uniqueNames.length === 0) return "another trainer"
+  if (uniqueNames.length === 1) return uniqueNames[0]
+  if (uniqueNames.length === 2) return `${uniqueNames[0]} and ${uniqueNames[1]}`
+  if (uniqueNames.length === 3) {
+    return `${uniqueNames[0]}, ${uniqueNames[1]} and ${uniqueNames[2]}`
+  }
+
+  return `${uniqueNames[0]}, ${uniqueNames[1]} and ${uniqueNames.length - 2} other trainers`
+}
+
 export const wantedTradeMatchesOffer = (wanted, offer) =>
   normalizedName(wanted?.pokemonName) === normalizedName(offer?.pokemonName) &&
   modifierDefinitions.every(([key]) => !wanted?.[key] || Boolean(offer?.[key]))
@@ -41,8 +56,11 @@ export const tradeNotificationInclude = {
 export const serializeTradeNotification = (notification) => ({
   id: notification.id,
   listingId: notification.listingId,
+  type: notification.type || "WISHLIST_MATCH",
   pokemonName: notification.pokemonName,
   modifierSummary: notification.modifierSummary,
+  matchedTrainerSummary: notification.matchedTrainerSummary,
+  matchedTrainerCount: notification.matchedTrainerCount || 0,
   createdAt: notification.createdAt.toISOString(),
   readAt: notification.readAt?.toISOString() || null,
   listing: {
@@ -69,9 +87,15 @@ export async function syncWantedTradeNotificationsForListing(listing) {
     where: {
       ownerId: { not: listing.ownerId },
     },
+    include: {
+      owner: {
+        select: { ign: true },
+      },
+    },
   })
 
-  const matches = new Map()
+  const wishlistNotifications = new Map()
+  const listingOwnerMatches = new Map()
 
   for (const wanted of wantedEntries) {
     const offer = offeredItems.find((item) =>
@@ -80,30 +104,68 @@ export async function syncWantedTradeNotificationsForListing(listing) {
 
     if (!offer) continue
 
-    const key = `${wanted.ownerId}:${normalizedName(wanted.pokemonName)}`
-    if (matches.has(key)) continue
+    const pokemonKey = normalizedName(wanted.pokemonName)
+    const wishlistKey = `${wanted.ownerId}:${pokemonKey}`
 
-    matches.set(key, {
-      ownerId: wanted.ownerId,
-      listingId: listing.id,
+    if (!wishlistNotifications.has(wishlistKey)) {
+      wishlistNotifications.set(wishlistKey, {
+        ownerId: wanted.ownerId,
+        listingId: listing.id,
+        type: "WISHLIST_MATCH",
+        pokemonName: wanted.pokemonName,
+        modifierSummary: tradeModifierLabels(offer).join(", ") || null,
+        matchedTrainerSummary: null,
+        matchedTrainerCount: 0,
+      })
+    }
+
+    const ownerMatch = listingOwnerMatches.get(pokemonKey) || {
+      offer,
       pokemonName: wanted.pokemonName,
-      modifierSummary: tradeModifierLabels(offer).join(", ") || null,
-    })
+      trainerNames: new Set(),
+    }
+
+    ownerMatch.trainerNames.add(wanted.owner?.ign || "Another trainer")
+    listingOwnerMatches.set(pokemonKey, ownerMatch)
   }
 
+  const listingOwnerNotifications = Array.from(listingOwnerMatches.values()).map(
+    ({ offer, pokemonName, trainerNames }) => {
+      const names = Array.from(trainerNames)
+
+      return {
+        ownerId: listing.ownerId,
+        listingId: listing.id,
+        type: "LISTING_MATCH",
+        pokemonName,
+        modifierSummary: tradeModifierLabels(offer).join(", ") || null,
+        matchedTrainerSummary: summarizeTrainerNames(names),
+        matchedTrainerCount: names.length,
+      }
+    },
+  )
+
+  const notifications = [
+    ...Array.from(wishlistNotifications.values()),
+    ...listingOwnerNotifications,
+  ]
+
   return Promise.all(
-    Array.from(matches.values()).map((match) =>
+    notifications.map((notification) =>
       prisma.tradeNotification.upsert({
         where: {
           ownerId_listingId_pokemonName: {
-            ownerId: match.ownerId,
-            listingId: match.listingId,
-            pokemonName: match.pokemonName,
+            ownerId: notification.ownerId,
+            listingId: notification.listingId,
+            pokemonName: notification.pokemonName,
           },
         },
-        create: match,
+        create: notification,
         update: {
-          modifierSummary: match.modifierSummary,
+          type: notification.type,
+          modifierSummary: notification.modifierSummary,
+          matchedTrainerSummary: notification.matchedTrainerSummary,
+          matchedTrainerCount: notification.matchedTrainerCount,
         },
       }),
     ),

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -15,6 +15,13 @@ const notificationMessage = (notification) => {
     ? `${notification.modifierSummary} `
     : ""
 
+  if (notification.type === "LISTING_MATCH") {
+    const trainers = notification.matchedTrainerSummary || "Another trainer"
+    const verb = notification.matchedTrainerCount === 1 ? "wants" : "want"
+
+    return `${trainers} ${verb} ${modifiers}${notification.pokemonName}, which you have offered in this listing.`
+  }
+
   return `${notification.listing.owner.ign} listed ${modifiers}${notification.pokemonName}, matching your wanted list.`
 }
 
@@ -69,7 +76,7 @@ export default function NotificationsPage({ initialNotifications, renderedAt }) 
         <div>
           <h1>Notifications</h1>
           <p className="muted">
-            Private alerts when another trainer offers something matching your wanted list.
+            Private alerts when someone offers something you want or when your listing matches another trainer&apos;s wanted list.
           </p>
         </div>
         {unreadCount > 0 && (

--- a/prisma/migrations/20260802095500_add_bidirectional_trade_notifications/migration.sql
+++ b/prisma/migrations/20260802095500_add_bidirectional_trade_notifications/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "TradeNotification" ADD COLUMN "type" TEXT NOT NULL DEFAULT 'WISHLIST_MATCH';
+ALTER TABLE "TradeNotification" ADD COLUMN "matchedTrainerSummary" TEXT;
+ALTER TABLE "TradeNotification" ADD COLUMN "matchedTrainerCount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,15 +112,18 @@ model WantedTrade {
 }
 
 model TradeNotification {
-  id              Int          @id @default(autoincrement())
-  ownerId         Int
-  owner           User         @relation(fields: [ownerId], references: [id], onDelete: Cascade)
-  listingId       Int
-  listing         TradeListing @relation(fields: [listingId], references: [id], onDelete: Cascade)
-  pokemonName     String
-  modifierSummary String?
-  createdAt       DateTime     @default(now())
-  readAt          DateTime?
+  id                    Int          @id @default(autoincrement())
+  ownerId               Int
+  owner                 User         @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  listingId             Int
+  listing               TradeListing @relation(fields: [listingId], references: [id], onDelete: Cascade)
+  type                   String       @default("WISHLIST_MATCH")
+  pokemonName            String
+  modifierSummary        String?
+  matchedTrainerSummary  String?
+  matchedTrainerCount    Int          @default(0)
+  createdAt              DateTime     @default(now())
+  readAt                 DateTime?
 
   @@unique([ownerId, listingId, pokemonName])
   @@index([ownerId, readAt, createdAt])


### PR DESCRIPTION
## What changed

- keeps the existing alert for the wishlist owner when another trainer offers a matching Pokémon
- adds a reciprocal private alert for the listing owner when their offered Pokémon matches someone else's wanted list
- aggregates several matching trainers into one owner alert per listing and Pokémon to avoid notification spam
- includes the matching trainer name, or a compact trainer summary for multiple matches
- preserves the existing modifier-aware matching rules and excludes the listing owner's own wanted entries
- adds notification type and match-summary fields through a Prisma migration
- updates the notifications page copy and messages for both alert directions
- adds regression tests covering two wishlist-owner alerts plus one aggregated listing-owner alert

## Validation

The Validate workflow will run dependency audits, ESLint, Jest and the production build.