### PR TITLE
Fix desktop ticker scrolling

### DIFF
--- a/styles/tickers.css
+++ b/styles/tickers.css
@@ -91,6 +91,20 @@
   font-size: 0.99rem !important;
 }
 
+/*
+ * Mouse hover previously left the desktop tickers paused whenever the pointer
+ * rested over the ticker stack. Keep animations moving for fine pointers while
+ * preserving keyboard focus pauses and the reduced-motion rules in each ticker.
+ */
+@media (hover: hover) and (pointer: fine) {
+  .event-ticker.paused:not(:focus-within) .ticker-track,
+  .raid-ticker.paused:not(:focus-within) .raid-track,
+  .ditto-ticker:hover:not(:focus-within) .ditto-track,
+  .new-gym-ticker:hover:not(:focus-within) .new-gym-track {
+    animation-play-state: running !important;
+  }
+}
+
 @media (max-width: 620px) {
   .event-ticker .ticker-label {
     padding: 0 13px !important;


### PR DESCRIPTION
## What changed

- fixes all scrolling tickers appearing frozen on desktop when the mouse rests over the ticker stack
- keeps upcoming events, raid bosses, Ditto disguises and new gyms moving for fine-pointer desktop devices
- preserves keyboard focus pauses for accessibility
- preserves each ticker's existing reduced-motion behaviour

## Root cause

The event and raid tickers set a paused state on mouse entry, while the Ditto and new-gym tickers pause through `:hover`. On desktop the pointer often remains over the ticker stack, making the animations appear permanently stopped. Mobile devices do not trigger that hover path.

## Validation

The Validate workflow will run dependency audits, ESLint, Jest and the production build.