### PR TITLE
Allow all registered users to access wanted trades

### DIFF
--- a/__tests__/wanted-trades-access.test.js
+++ b/__tests__/wanted-trades-access.test.js
@@ -1,0 +1,76 @@
+const fs = require("fs")
+const path = require("path")
+
+jest.mock("../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}))
+
+const prisma = require("../lib/prisma").default
+const {
+  getAuthenticatedUser,
+  getEligibleTradeUser,
+} = require("../lib/tradeServer")
+
+const session = {
+  user: {
+    id: 42,
+    ign: "NoCodeTrainer",
+    role: "user",
+  },
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("wanted trade access", () => {
+  it("recognises a registered user without a friend code", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: 42,
+      ign: "NoCodeTrainer",
+      role: "user",
+      entries: [],
+    })
+
+    await expect(getAuthenticatedUser(session)).resolves.toEqual({
+      id: 42,
+      ign: "NoCodeTrainer",
+      role: "user",
+      friendCode: null,
+    })
+  })
+
+  it("keeps full trade-listing eligibility dependent on a friend code", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: 42,
+      ign: "NoCodeTrainer",
+      role: "user",
+      entries: [],
+    })
+
+    await expect(getEligibleTradeUser(session)).resolves.toBeNull()
+  })
+
+  it("uses registered-user access throughout the wanted board", () => {
+    const files = [
+      "pages/trades/wanted.js",
+      "pages/api/trades/wanted/index.js",
+      "pages/api/trades/wanted/[id].js",
+    ].map((file) =>
+      fs.readFileSync(path.join(process.cwd(), file), "utf8"),
+    )
+
+    for (const source of files) {
+      expect(source).toContain("getAuthenticatedUser")
+      expect(source).not.toContain("getEligibleTradeUser")
+      expect(source).not.toContain("FRIEND_CODE_REQUIRED")
+    }
+
+    expect(files[0]).not.toContain('destination: "/friend-codes"')
+  })
+})

--- a/lib/tradeServer.js
+++ b/lib/tradeServer.js
@@ -18,7 +18,7 @@ export const tradeListingInclude = {
   },
 }
 
-export const getEligibleTradeUser = async (session) => {
+export const getAuthenticatedUser = async (session) => {
   const userId = Number(session?.user?.id)
 
   if (!Number.isInteger(userId)) return null
@@ -37,16 +37,21 @@ export const getEligibleTradeUser = async (session) => {
     },
   })
 
-  const friendCode = normalizeFriendCode(user?.entries?.[0]?.code)
-
-  if (!user || !friendCode) return null
+  if (!user) return null
 
   return {
     id: user.id,
     ign: user.ign,
     role: user.role,
-    friendCode,
+    friendCode: normalizeFriendCode(user.entries?.[0]?.code),
   }
+}
+
+export const getEligibleTradeUser = async (session) => {
+  const user = await getAuthenticatedUser(session)
+
+  if (!user?.friendCode) return null
+  return user
 }
 
 export const purgeExpiredTradeListings = async () =>

--- a/pages/api/trades/wanted/[id].js
+++ b/pages/api/trades/wanted/[id].js
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "../../auth/[...nextauth]"
 import prisma from "../../../../lib/prisma"
-import { getEligibleTradeUser } from "../../../../lib/tradeServer"
+import { getAuthenticatedUser } from "../../../../lib/tradeServer"
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions)
@@ -10,13 +10,10 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: "You must be logged in." })
   }
 
-  const tradeUser = await getEligibleTradeUser(session)
+  const currentUser = await getAuthenticatedUser(session)
 
-  if (!tradeUser) {
-    return res.status(403).json({
-      error: "Add a valid 12-digit friend code to your account before using trades.",
-      code: "FRIEND_CODE_REQUIRED",
-    })
+  if (!currentUser) {
+    return res.status(401).json({ error: "Your account could not be found." })
   }
 
   if (req.method !== "DELETE") {
@@ -39,7 +36,7 @@ export default async function handler(req, res) {
     return res.status(404).json({ error: "Wanted trade not found." })
   }
 
-  if (entry.ownerId !== tradeUser.id && tradeUser.role !== "admin") {
+  if (entry.ownerId !== currentUser.id && currentUser.role !== "admin") {
     return res.status(403).json({ error: "You can only remove your own wanted trades." })
   }
 

--- a/pages/api/trades/wanted/index.js
+++ b/pages/api/trades/wanted/index.js
@@ -2,7 +2,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "../../auth/[...nextauth]"
 import prisma from "../../../../lib/prisma"
 import pokedexByRegion from "../../../../lib/pokedexData"
-import { getEligibleTradeUser } from "../../../../lib/tradeServer"
+import { getAuthenticatedUser } from "../../../../lib/tradeServer"
 import {
   buildReleasedPokemonOptions,
   serializeWantedTrade,
@@ -18,13 +18,10 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: "You must be logged in." })
   }
 
-  const tradeUser = await getEligibleTradeUser(session)
+  const currentUser = await getAuthenticatedUser(session)
 
-  if (!tradeUser) {
-    return res.status(403).json({
-      error: "Add a valid 12-digit friend code to your account before using trades.",
-      code: "FRIEND_CODE_REQUIRED",
-    })
+  if (!currentUser) {
+    return res.status(401).json({ error: "Your account could not be found." })
   }
 
   if (req.method === "GET") {
@@ -62,7 +59,7 @@ export default async function handler(req, res) {
     }
 
     const duplicate = await prisma.wantedTrade.findFirst({
-      where: wantedTradeDuplicateWhere(tradeUser.id, validated.value),
+      where: wantedTradeDuplicateWhere(currentUser.id, validated.value),
       select: { id: true },
     })
 
@@ -74,7 +71,7 @@ export default async function handler(req, res) {
 
     const entry = await prisma.wantedTrade.create({
       data: {
-        ownerId: tradeUser.id,
+        ownerId: currentUser.id,
         ...validated.value,
       },
       include: wantedTradeInclude,

--- a/pages/trades/wanted.js
+++ b/pages/trades/wanted.js
@@ -4,7 +4,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "../api/auth/[...nextauth]"
 import prisma from "../../lib/prisma"
 import pokedexByRegion from "../../lib/pokedexData"
-import { getEligibleTradeUser } from "../../lib/tradeServer"
+import { getAuthenticatedUser } from "../../lib/tradeServer"
 import { formatFriendCode } from "../../lib/tradeUtils"
 import {
   buildReleasedPokemonOptions,
@@ -386,11 +386,11 @@ export async function getServerSideProps(context) {
     }
   }
 
-  const tradeUser = await getEligibleTradeUser(session)
+  const currentUser = await getAuthenticatedUser(session)
 
-  if (!tradeUser) {
+  if (!currentUser) {
     return {
-      redirect: { destination: "/friend-codes", permanent: false },
+      redirect: { destination: "/login", permanent: false },
     }
   }
 
@@ -420,8 +420,8 @@ export async function getServerSideProps(context) {
     props: {
       initialEntries: entries.map(serializeWantedTrade),
       pokemonOptions,
-      currentUserId: tradeUser.id,
-      isAdmin: tradeUser.role === "admin",
+      currentUserId: currentUser.id,
+      isAdmin: currentUser.role === "admin",
       releaseDataStale,
       releaseDataError,
     },


### PR DESCRIPTION
## What changed

- removes the friend-code requirement from the wanted trade board
- allows any authenticated account to view, add and remove its own wanted entries
- keeps friend codes optional in wanted-board cards
- preserves the valid friend-code requirement for full trade listings
- separates the shared authenticated-user lookup from full trade eligibility
- adds regression coverage for registered users with no friend-code entry

## Root cause

The wanted board reused the full trade-listing eligibility helper, so logged-in users without a valid 12-digit friend code were redirected to `/friend-codes`. The original requirement for the wanted board was registered users only.

## Validation

The Validate workflow will run dependency audits, ESLint, Jest and the production build.