### PR TITLE
Store friend codes in canonical four-digit blocks

### DIFF
--- a/__tests__/api/entries.test.js
+++ b/__tests__/api/entries.test.js
@@ -84,7 +84,7 @@ describe("POST /api/entries", () => {
     expect(JSON.parse(res._getData())).toEqual({ error: "You must be logged in." });
   });
 
-  it("creates an entry when the session is valid", async () => {
+  it("stores a valid friend code as three blocks of four digits", async () => {
     const user = await prisma.user.create({
       data: { ign: "misty", password: "hashed", role: "user" },
     });
@@ -103,11 +103,33 @@ describe("POST /api/entries", () => {
     expect(res._getStatusCode()).toBe(201);
     const payload = JSON.parse(res._getData());
     expect(payload.trainerName).toBe("Misty");
-    expect(payload.code).toBe("4444-5555-6666");
+    expect(payload.code).toBe("4444 5555 6666");
     expect(payload.ownerId).toBe(user.id);
 
     const entries = await prisma.entry.findMany();
     expect(entries).toHaveLength(1);
     expect(entries[0].trainerName).toBe("Misty");
+    expect(entries[0].code).toBe("4444 5555 6666");
+  });
+
+  it("rejects malformed friend codes instead of storing them", async () => {
+    const user = await prisma.user.create({
+      data: { ign: "brock", password: "hashed", role: "user" },
+    });
+
+    getServerSession.mockResolvedValueOnce({
+      user: { id: user.id, ign: user.ign, role: user.role },
+    });
+
+    const { req, res } = createMocks({
+      method: "POST",
+      body: { trainerName: "Brock", friendCode: "1234 5678" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(JSON.parse(res._getData()).error).toContain("exactly 12 digits");
+    expect(await prisma.entry.count()).toBe(0);
   });
 });

--- a/__tests__/api/entries.test.js
+++ b/__tests__/api/entries.test.js
@@ -5,6 +5,8 @@
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || "file:memdb1?mode=memory&cache=shared";
 
+const fs = require("fs");
+const path = require("path");
 const { createMocks } = require("node-mocks-http");
 const { getServerSession } = require("next-auth/next");
 
@@ -131,5 +133,54 @@ describe("POST /api/entries", () => {
     expect(res._getStatusCode()).toBe(400);
     expect(JSON.parse(res._getData()).error).toContain("exactly 12 digits");
     expect(await prisma.entry.count()).toBe(0);
+  });
+});
+
+describe("friend code migration", () => {
+  it("repairs legacy separators and clears malformed rows", async () => {
+    const user = await prisma.user.create({
+      data: { ign: "legacy", password: "hashed", role: "user" },
+    });
+
+    await prisma.entry.createMany({
+      data: [
+        {
+          trainerName: "DigitsOnly",
+          code: "111122223333",
+          ownerId: user.id,
+        },
+        {
+          trainerName: "Hyphenated",
+          code: "4444-5555-6666",
+          ownerId: user.id,
+        },
+        {
+          trainerName: "Malformed",
+          code: "1234 5678",
+          ownerId: user.id,
+        },
+      ],
+    });
+
+    const migration = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "prisma/migrations/20260802123000_normalize_friend_codes/migration.sql",
+      ),
+      "utf8",
+    );
+
+    await prisma.$executeRawUnsafe(migration);
+
+    const entries = await prisma.entry.findMany({
+      orderBy: { trainerName: "asc" },
+      select: { trainerName: true, code: true },
+    });
+
+    expect(entries).toEqual([
+      { trainerName: "DigitsOnly", code: "1111 2222 3333" },
+      { trainerName: "Hyphenated", code: "4444 5555 6666" },
+      { trainerName: "Malformed", code: "" },
+    ]);
   });
 });

--- a/__tests__/friend-code-format.test.js
+++ b/__tests__/friend-code-format.test.js
@@ -1,0 +1,56 @@
+const fs = require("fs")
+const path = require("path")
+const {
+  canonicalFriendCode,
+  formatFriendCode,
+  formatFriendCodeInput,
+  normalizeFriendCode,
+} = require("../lib/friendCode")
+
+describe("friend code formatting", () => {
+  it("formats typing into three blocks of four digits", () => {
+    expect(formatFriendCodeInput("123456789012")).toBe("1234 5678 9012")
+    expect(formatFriendCodeInput("1234-5678-9012")).toBe("1234 5678 9012")
+    expect(formatFriendCodeInput("12345")).toBe("1234 5")
+  })
+
+  it("limits form input to 12 digits", () => {
+    expect(formatFriendCodeInput("1234567890129999")).toBe("1234 5678 9012")
+  })
+
+  it("normalizes valid codes and rejects malformed values", () => {
+    expect(normalizeFriendCode("1234 5678 9012")).toBe("123456789012")
+    expect(formatFriendCode("1234.5678.9012")).toBe("1234 5678 9012")
+    expect(canonicalFriendCode("1234-5678-9012")).toBe("1234 5678 9012")
+    expect(canonicalFriendCode("1234 5678")).toBeNull()
+    expect(canonicalFriendCode("1234567890123")).toBeNull()
+  })
+
+  it("enforces canonical storage in every friend-code write API", () => {
+    const files = [
+      "pages/api/entries.js",
+      "pages/api/account.js",
+      "pages/api/entries/[id].js",
+      "pages/api/admin/entries/[id].js",
+    ]
+
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(process.cwd(), file), "utf8")
+      expect(source).toContain("canonicalFriendCode")
+    }
+  })
+
+  it("includes a migration for legacy database rows", () => {
+    const migration = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "prisma/migrations/20260802123000_normalize_friend_codes/migration.sql",
+      ),
+      "utf8",
+    )
+
+    expect(migration).toContain("WITH RECURSIVE")
+    expect(migration).toContain("length(\"digits\") = 12")
+    expect(migration).toContain("UPDATE \"Entry\"")
+  })
+})

--- a/lib/friendCode.js
+++ b/lib/friendCode.js
@@ -1,0 +1,20 @@
+const FRIEND_CODE_DIGIT_COUNT = 12
+
+const digitsOnly = (value) => String(value ?? "").replace(/\D/g, "")
+
+export const normalizeFriendCode = (value) => {
+  const digits = digitsOnly(value)
+  return digits.length === FRIEND_CODE_DIGIT_COUNT ? digits : null
+}
+
+export const formatFriendCode = (value) => {
+  const digits = normalizeFriendCode(value)
+  return digits ? digits.replace(/(\d{4})(?=\d)/g, "$1 ") : ""
+}
+
+export const formatFriendCodeInput = (value) =>
+  digitsOnly(value)
+    .slice(0, FRIEND_CODE_DIGIT_COUNT)
+    .replace(/(\d{4})(?=\d)/g, "$1 ")
+
+export const canonicalFriendCode = (value) => formatFriendCode(value) || null

--- a/lib/tradeUtils.js
+++ b/lib/tradeUtils.js
@@ -1,3 +1,7 @@
+import { formatFriendCode, normalizeFriendCode } from "./friendCode"
+
+export { formatFriendCode, normalizeFriendCode }
+
 const MAX_ITEMS_PER_SIDE = 20
 const MAX_POKEMON_NAME_LENGTH = 100
 const MAX_ITEM_NOTES_LENGTH = 250
@@ -6,16 +10,6 @@ const MAX_LISTING_NOTES_LENGTH = 1000
 
 const cleanText = (value, maxLength) =>
   String(value ?? "").trim().slice(0, maxLength)
-
-export const normalizeFriendCode = (value) => {
-  const digits = String(value ?? "").replace(/\D/g, "")
-  return digits.length === 12 ? digits : null
-}
-
-export const formatFriendCode = (value) => {
-  const digits = normalizeFriendCode(value)
-  return digits ? digits.replace(/(\d{4})(?=\d)/g, "$1 ") : ""
-}
 
 export const addOneMonth = (value = new Date()) => {
   const source = new Date(value)

--- a/pages/account.js
+++ b/pages/account.js
@@ -3,13 +3,16 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "./api/auth/[...nextauth]"
 import prisma from "../lib/prisma"
 import TeamBadge from "../components/TeamBadge"
+import { formatFriendCodeInput } from "../lib/friendCode"
 
 export default function Account({ entry }) {
   const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [status, setStatus] = useState({ type: "", message: "" })
-  const [friendCode, setFriendCode] = useState(entry?.friendCode || "")
+  const [friendCode, setFriendCode] = useState(
+    formatFriendCodeInput(entry?.friendCode || ""),
+  )
   const [team, setTeam] = useState(entry?.team || "MYSTIC")
   const [profileStatus, setProfileStatus] = useState({ type: "", message: "" })
 
@@ -62,7 +65,9 @@ export default function Account({ entry }) {
     }
 
     if (data.team) setTeam(data.team)
-    if (typeof data.friendCode === "string") setFriendCode(data.friendCode)
+    if (typeof data.friendCode === "string") {
+      setFriendCode(formatFriendCodeInput(data.friendCode))
+    }
 
     setProfileStatus({ type: "success", message: "Trainer profile updated" })
   }
@@ -87,8 +92,11 @@ export default function Account({ entry }) {
             Friend code
             <input
               type="text"
+              inputMode="numeric"
+              autoComplete="off"
+              maxLength={14}
               value={friendCode}
-              onChange={(e) => setFriendCode(e.target.value)}
+              onChange={(e) => setFriendCode(formatFriendCodeInput(e.target.value))}
               placeholder="0000 0000 0000"
             />
           </label>

--- a/pages/api/account.js
+++ b/pages/api/account.js
@@ -41,7 +41,10 @@ export default async function handler(req, res) {
         ? await prisma.entry.update({
             where: { id: latestEntry.id },
             data: {
-              code: normalizedFriendCode || latestEntry.code,
+              code:
+                normalizedFriendCode ||
+                canonicalFriendCode(latestEntry.code) ||
+                "",
               team: normalizedTeam,
             },
           })

--- a/pages/api/account.js
+++ b/pages/api/account.js
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "./auth/[...nextauth]"
 import prisma from "../../lib/prisma"
+import { canonicalFriendCode } from "../../lib/friendCode"
 
 const VALID_TEAMS = ["INSTINCT", "MYSTIC", "VALOR"]
 
@@ -18,8 +19,19 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: "Invalid team selection" })
     }
 
+    const hasFriendCode = String(friendCode ?? "").trim().length > 0
+    const normalizedFriendCode = hasFriendCode
+      ? canonicalFriendCode(friendCode)
+      : null
+
+    if (hasFriendCode && !normalizedFriendCode) {
+      return res.status(400).json({
+        error: "Friend code must contain exactly 12 digits.",
+      })
+    }
+
     try {
-      const normalizedTeam = (team || "MYSTIC").toUpperCase()
+      const normalizedTeam = String(team || "MYSTIC").toUpperCase()
       const latestEntry = await prisma.entry.findFirst({
         where: { ownerId: session.user.id },
         orderBy: { createdAt: "desc" },
@@ -28,12 +40,15 @@ export default async function handler(req, res) {
       const updatedEntry = latestEntry
         ? await prisma.entry.update({
             where: { id: latestEntry.id },
-            data: { code: friendCode || latestEntry.code, team: normalizedTeam },
+            data: {
+              code: normalizedFriendCode || latestEntry.code,
+              team: normalizedTeam,
+            },
           })
         : await prisma.entry.create({
             data: {
               trainerName: session.user.ign,
-              code: friendCode || "",
+              code: normalizedFriendCode || "",
               team: normalizedTeam,
               ownerId: session.user.id,
             },

--- a/pages/api/admin/entries/[id].js
+++ b/pages/api/admin/entries/[id].js
@@ -1,5 +1,6 @@
 import { getSession } from "next-auth/react";
 import prisma from "../../../../lib/prisma";
+import { canonicalFriendCode } from "../../../../lib/friendCode";
 
 export default async function handler(req, res) {
   const session = await getSession({ req });
@@ -16,14 +17,25 @@ export default async function handler(req, res) {
 
   if (req.method === "PUT") {
     const { trainerName, friendCode } = req.body;
+    const normalizedTrainerName = String(trainerName || "").trim();
+    const normalizedFriendCode = canonicalFriendCode(friendCode);
 
-    if (!trainerName || !friendCode) {
+    if (!normalizedTrainerName || !friendCode) {
       return res.status(400).json({ message: "Missing fields" });
+    }
+
+    if (!normalizedFriendCode) {
+      return res.status(400).json({
+        message: "Friend code must contain exactly 12 digits.",
+      });
     }
 
     const updated = await prisma.entry.update({
       where: { id: Number(id) },
-      data: { trainerName, code: friendCode },
+      data: {
+        trainerName: normalizedTrainerName,
+        code: normalizedFriendCode,
+      },
     });
     return res.json(updated);
   }

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "./auth/[...nextauth]";
 import prisma from "../../lib/prisma";
+import { canonicalFriendCode } from "../../lib/friendCode";
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions);
@@ -13,11 +14,19 @@ export default async function handler(req, res) {
     try {
       const { trainerName, friendCode, team } = req.body;
 
+      const normalizedTrainerName = String(trainerName || "").trim();
+      const normalizedFriendCode = canonicalFriendCode(friendCode);
       const normalizedTeam = String(team || "MYSTIC").toUpperCase();
       const validTeams = ["INSTINCT", "MYSTIC", "VALOR"];
 
-      if (!trainerName || !friendCode) {
+      if (!normalizedTrainerName || !friendCode) {
         return res.status(400).json({ error: "All fields are required." });
+      }
+
+      if (!normalizedFriendCode) {
+        return res.status(400).json({
+          error: "Friend code must contain exactly 12 digits.",
+        });
       }
 
       if (!validTeams.includes(normalizedTeam)) {
@@ -26,8 +35,8 @@ export default async function handler(req, res) {
 
       const entry = await prisma.entry.create({
         data: {
-          trainerName,
-          code: friendCode,
+          trainerName: normalizedTrainerName,
+          code: normalizedFriendCode,
           team: normalizedTeam,
           ownerId: session.user.id,
         },

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -1,5 +1,6 @@
 import { getSession } from "next-auth/react";
 import prisma from "../../../lib/prisma";
+import { canonicalFriendCode } from "../../../lib/friendCode";
 
 export default async function handler(req, res) {
   const session = await getSession({ req });
@@ -27,15 +28,26 @@ export default async function handler(req, res) {
     }
 
     const { trainerName, friendCode } = req.body;
+    const normalizedTrainerName = String(trainerName || "").trim();
+    const normalizedFriendCode = canonicalFriendCode(friendCode);
 
-    if (!trainerName || !friendCode) {
+    if (!normalizedTrainerName || !friendCode) {
       return res.status(400).json({ error: "Missing fields" });
+    }
+
+    if (!normalizedFriendCode) {
+      return res.status(400).json({
+        error: "Friend code must contain exactly 12 digits.",
+      });
     }
 
     try {
       const updatedEntry = await prisma.entry.update({
         where: { id: entryId },
-        data: { trainerName, code: friendCode },
+        data: {
+          trainerName: normalizedTrainerName,
+          code: normalizedFriendCode,
+        },
       });
       res.status(200).json(updatedEntry);
     } catch (err) {

--- a/pages/entries/add.js
+++ b/pages/entries/add.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useSession } from "next-auth/react";
+import { formatFriendCodeInput } from "../../lib/friendCode";
 
 export default function AddEntry() {
   const { data: session } = useSession();
@@ -50,9 +51,12 @@ export default function AddEntry() {
         />
         <input
           type="text"
-          placeholder="Friend Code"
+          inputMode="numeric"
+          autoComplete="off"
+          maxLength={14}
+          placeholder="0000 0000 0000"
           value={friendCode}
-          onChange={(e) => setFriendCode(e.target.value)}
+          onChange={(e) => setFriendCode(formatFriendCodeInput(e.target.value))}
           required
         />
         <select value={team} onChange={(e) => setTeam(e.target.value)}>

--- a/pages/friend-codes.js
+++ b/pages/friend-codes.js
@@ -3,6 +3,10 @@ import { useSession } from "next-auth/react"
 import { useState } from "react"
 import prisma from "../lib/prisma"
 import TeamBadge from "../components/TeamBadge"
+import {
+  formatFriendCodeInput,
+  normalizeFriendCode,
+} from "../lib/friendCode"
 
 async function copyTextToClipboard(value) {
   if (navigator.clipboard?.writeText && window.isSecureContext) {
@@ -69,7 +73,7 @@ export default function FriendCodes({ entries }) {
   }
 
   const handleCopyFriendCode = async (entry) => {
-    const code = String(entry.code || "").replace(/\D/g, "")
+    const code = normalizeFriendCode(entry.code)
 
     if (!code) {
       setCopyError("This entry does not have a valid friend code to copy.")
@@ -124,9 +128,12 @@ export default function FriendCodes({ entries }) {
                 <input
                   id="friendCode"
                   type="text"
-                  placeholder="Friend Code"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  maxLength={14}
+                  placeholder="0000 0000 0000"
                   value={friendCode}
-                  onChange={(e) => setFriendCode(e.target.value)}
+                  onChange={(e) => setFriendCode(formatFriendCodeInput(e.target.value))}
                   required
                 />
               </div>
@@ -153,7 +160,8 @@ export default function FriendCodes({ entries }) {
           ) : (
             <ul className="entry-list">
               {entryList.map((entry) => {
-                const hasCode = /\d/.test(String(entry.code || ""))
+                const formattedCode = formatFriendCodeInput(entry.code)
+                const hasCode = Boolean(normalizeFriendCode(entry.code))
                 const copied = copiedEntryId === entry.id
 
                 return (
@@ -163,7 +171,9 @@ export default function FriendCodes({ entries }) {
                       <strong>{entry.trainerName || entry.owner.ign}</strong>
                     </div>
                     <div className="entry-code-actions">
-                      <div className="entry-code">{entry.code || "No code provided"}</div>
+                      <div className="entry-code">
+                        {hasCode ? formattedCode : "No code provided"}
+                      </div>
                       {hasCode && (
                         <button
                           type="button"

--- a/prisma/migrations/20260802123000_normalize_friend_codes/migration.sql
+++ b/prisma/migrations/20260802123000_normalize_friend_codes/migration.sql
@@ -1,0 +1,41 @@
+-- Store every valid friend code as three blocks of four digits.
+-- Legacy values with exactly 12 digits are repaired regardless of separators.
+-- Malformed legacy values are cleared so they are no longer treated as valid codes.
+WITH RECURSIVE
+friend_code_digits("id", "source", "position", "digits") AS (
+  SELECT "id", COALESCE("code", ''), 1, ''
+  FROM "Entry"
+
+  UNION ALL
+
+  SELECT
+    "id",
+    "source",
+    "position" + 1,
+    "digits" ||
+      CASE
+        WHEN substr("source", "position", 1) GLOB '[0-9]'
+          THEN substr("source", "position", 1)
+        ELSE ''
+      END
+  FROM friend_code_digits
+  WHERE "position" <= length("source")
+),
+normalized_friend_codes("id", "digits") AS (
+  SELECT "id", "digits"
+  FROM friend_code_digits
+  WHERE "position" = length("source") + 1
+)
+UPDATE "Entry"
+SET "code" = COALESCE((
+  SELECT
+    CASE
+      WHEN length("digits") = 12 THEN
+        substr("digits", 1, 4) || ' ' ||
+        substr("digits", 5, 4) || ' ' ||
+        substr("digits", 9, 4)
+      ELSE ''
+    END
+  FROM normalized_friend_codes
+  WHERE normalized_friend_codes."id" = "Entry"."id"
+), '');


### PR DESCRIPTION
## What changed

- adds shared friend-code parsing and formatting utilities
- formats friend-code inputs live as `1234 5678 9012`
- validates every friend-code creation and edit API independently
- stores valid codes in the database only as three blocks of four digits
- rejects malformed new values instead of saving them
- adds a Prisma migration that repairs existing valid codes regardless of separators
- clears malformed legacy values so they are no longer treated as usable friend codes
- keeps trade and wanted-board friend-code handling backed by the shared formatter
- adds unit, API and migration regression tests

## Covered write paths

- community friend-code entry creation
- standalone add-entry page
- account profile updates
- owner entry edits
- admin entry edits

## Deployment

This includes a data migration, so `npm run db:deploy` is required before restarting the service.

## Validation

The Validate workflow will run dependency audits, ESLint, Jest (including the SQLite migration test) and the production build.