### PR TITLE
Fix friend-code entry form updates

### DIFF
--- a/__tests__/api/entry-edit.test.js
+++ b/__tests__/api/entry-edit.test.js
@@ -1,0 +1,125 @@
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL || "file:entry-edit-tests?mode=memory&cache=shared"
+
+const { createMocks } = require("node-mocks-http")
+const { getServerSession } = require("next-auth/next")
+
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}))
+
+jest.mock("../../pages/api/auth/[...nextauth]", () => ({
+  authOptions: {},
+}))
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    entry: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}))
+
+const prisma = require("../../lib/prisma").default
+const ownerHandler = require("../../pages/api/entries/[id]").default
+const adminHandler = require("../../pages/api/admin/entries/[id]").default
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("friend-code entry editing", () => {
+  it("allows an owner whose session ID is a string to update their entry", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: "42", ign: "misty", role: "user" },
+    })
+    prisma.entry.findUnique.mockResolvedValueOnce({
+      id: 7,
+      ownerId: 42,
+      trainerName: "Misty",
+      code: "",
+    })
+    prisma.entry.update.mockResolvedValueOnce({
+      id: 7,
+      ownerId: 42,
+      trainerName: "Misty",
+      code: "1234 5678 9012",
+    })
+
+    const { req, res } = createMocks({
+      method: "PATCH",
+      query: { id: "7" },
+      body: {
+        trainerName: "Misty",
+        friendCode: "1234-5678-9012",
+      },
+    })
+
+    await ownerHandler(req, res)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(prisma.entry.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: {
+        trainerName: "Misty",
+        code: "1234 5678 9012",
+      },
+    })
+  })
+
+  it("allows an admin form update and stores the canonical code", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: "1", ign: "admin", role: "admin" },
+    })
+    prisma.entry.update.mockResolvedValueOnce({
+      id: 9,
+      ownerId: 42,
+      trainerName: "Brock",
+      code: "9876 5432 1098",
+    })
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      query: { id: "9" },
+      body: {
+        trainerName: " Brock ",
+        friendCode: "987654321098",
+      },
+    })
+
+    await adminHandler(req, res)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(prisma.entry.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: {
+        trainerName: "Brock",
+        code: "9876 5432 1098",
+      },
+    })
+  })
+
+  it("returns a useful validation error for an incomplete code", async () => {
+    getServerSession.mockResolvedValueOnce({
+      user: { id: "1", ign: "admin", role: "admin" },
+    })
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      query: { id: "9" },
+      body: {
+        trainerName: "Brock",
+        friendCode: "1234 5678",
+      },
+    })
+
+    await adminHandler(req, res)
+
+    expect(res._getStatusCode()).toBe(400)
+    expect(JSON.parse(res._getData()).message).toContain("exactly 12 digits")
+    expect(prisma.entry.update).not.toHaveBeenCalled()
+  })
+})

--- a/pages/api/admin/entries/[id].js
+++ b/pages/api/admin/entries/[id].js
@@ -1,18 +1,29 @@
-import { getSession } from "next-auth/react";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
 import prisma from "../../../../lib/prisma";
 import { canonicalFriendCode } from "../../../../lib/friendCode";
 
 export default async function handler(req, res) {
-  const session = await getSession({ req });
-  if (!session || session.user.role !== "admin") {
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session || session.user?.role !== "admin") {
     return res.status(403).json({ message: "Access denied" });
   }
 
-  const { id } = req.query;
+  const entryId = Number(req.query.id);
+
+  if (!Number.isInteger(entryId) || entryId <= 0) {
+    return res.status(400).json({ message: "Invalid entry ID." });
+  }
 
   if (req.method === "DELETE") {
-    await prisma.entry.delete({ where: { id: Number(id) } });
-    return res.status(204).end();
+    try {
+      await prisma.entry.delete({ where: { id: entryId } });
+      return res.status(204).end();
+    } catch (error) {
+      console.error("Failed to delete friend-code entry", error);
+      return res.status(500).json({ message: "Failed to delete entry" });
+    }
   }
 
   if (req.method === "PUT") {
@@ -20,8 +31,10 @@ export default async function handler(req, res) {
     const normalizedTrainerName = String(trainerName || "").trim();
     const normalizedFriendCode = canonicalFriendCode(friendCode);
 
-    if (!normalizedTrainerName || !friendCode) {
-      return res.status(400).json({ message: "Missing fields" });
+    if (!normalizedTrainerName || !String(friendCode ?? "").trim()) {
+      return res.status(400).json({
+        message: "Trainer name and friend code are required.",
+      });
     }
 
     if (!normalizedFriendCode) {
@@ -30,15 +43,21 @@ export default async function handler(req, res) {
       });
     }
 
-    const updated = await prisma.entry.update({
-      where: { id: Number(id) },
-      data: {
-        trainerName: normalizedTrainerName,
-        code: normalizedFriendCode,
-      },
-    });
-    return res.json(updated);
+    try {
+      const updated = await prisma.entry.update({
+        where: { id: entryId },
+        data: {
+          trainerName: normalizedTrainerName,
+          code: normalizedFriendCode,
+        },
+      });
+      return res.status(200).json(updated);
+    } catch (error) {
+      console.error("Failed to update friend-code entry", error);
+      return res.status(500).json({ message: "Failed to update entry" });
+    }
   }
 
-  res.status(405).json({ message: "Method not allowed" });
+  res.setHeader("Allow", ["PUT", "DELETE"]);
+  return res.status(405).json({ message: "Method not allowed" });
 }

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -1,15 +1,25 @@
-import { getSession } from "next-auth/react";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
 import prisma from "../../../lib/prisma";
 import { canonicalFriendCode } from "../../../lib/friendCode";
 
 export default async function handler(req, res) {
-  const session = await getSession({ req });
+  const session = await getServerSession(req, res, authOptions);
 
   if (!session) {
-    return res.status(403).json({ error: "Access denied" });
+    return res.status(401).json({ error: "You must be logged in." });
   }
 
-  const entryId = parseInt(req.query.id);
+  const entryId = Number(req.query.id);
+  const currentUserId = Number(session.user?.id);
+
+  if (!Number.isInteger(entryId) || entryId <= 0) {
+    return res.status(400).json({ error: "Invalid entry ID." });
+  }
+
+  if (!Number.isInteger(currentUserId)) {
+    return res.status(401).json({ error: "Your account could not be identified." });
+  }
 
   const existingEntry = await prisma.entry.findUnique({
     where: { id: entryId },
@@ -19,7 +29,7 @@ export default async function handler(req, res) {
     return res.status(404).json({ error: "Entry not found" });
   }
 
-  const isOwner = existingEntry.ownerId === session.user.id;
+  const isOwner = existingEntry.ownerId === currentUserId;
   const isAdmin = session.user.role === "admin";
 
   if (req.method === "PATCH") {
@@ -31,8 +41,8 @@ export default async function handler(req, res) {
     const normalizedTrainerName = String(trainerName || "").trim();
     const normalizedFriendCode = canonicalFriendCode(friendCode);
 
-    if (!normalizedTrainerName || !friendCode) {
-      return res.status(400).json({ error: "Missing fields" });
+    if (!normalizedTrainerName || !String(friendCode ?? "").trim()) {
+      return res.status(400).json({ error: "Trainer name and friend code are required." });
     }
 
     if (!normalizedFriendCode) {
@@ -49,26 +59,27 @@ export default async function handler(req, res) {
           code: normalizedFriendCode,
         },
       });
-      res.status(200).json(updatedEntry);
+      return res.status(200).json(updatedEntry);
     } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Failed to update entry" });
+      console.error("Failed to update friend-code entry", err);
+      return res.status(500).json({ error: "Failed to update entry" });
     }
+  }
 
-  } else if (req.method === "DELETE") {
+  if (req.method === "DELETE") {
     if (!isAdmin) {
       return res.status(403).json({ error: "Access denied" });
     }
 
     try {
       await prisma.entry.delete({ where: { id: entryId } });
-      res.status(200).json({ message: "Entry deleted" });
+      return res.status(200).json({ message: "Entry deleted" });
     } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Failed to delete entry" });
+      console.error("Failed to delete friend-code entry", err);
+      return res.status(500).json({ error: "Failed to delete entry" });
     }
-
-  } else {
-    res.status(405).json({ error: "Method not allowed" });
   }
+
+  res.setHeader("Allow", ["PATCH", "DELETE"]);
+  return res.status(405).json({ error: "Method not allowed" });
 }


### PR DESCRIPTION
## What changed

- replaces the legacy `getSession` usage in both friend-code entry edit APIs with `getServerSession`
- normalizes session user IDs before comparing them with numeric database owner IDs
- restores owner updates when the JWT session ID is a string
- keeps admin entry edits working with canonical friend-code storage
- validates entry IDs and returns clearer API errors
- adds regression coverage for owner edits, admin edits and incomplete friend codes

## Scope

This does not change or rerun the previous friend-code migration and does not alter any stored data by itself.

## Validation

The Validate workflow will run audits, lint, Jest and the production build.