### PR TITLE
Add friendship requirements to trade listings

### DIFF
--- a/__tests__/api/trades.test.js
+++ b/__tests__/api/trades.test.js
@@ -60,6 +60,7 @@ const ensureSchema = async () => {
     CREATE TABLE "TradeListing" (
       "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       "ownerId" INTEGER NOT NULL,
+      "friendshipRequirement" TEXT NOT NULL DEFAULT 'ANY',
       "location" TEXT,
       "notes" TEXT,
       "status" TEXT NOT NULL DEFAULT 'ACTIVE',
@@ -154,7 +155,7 @@ describe("POST /api/trades", () => {
     expect(JSON.parse(res._getData()).code).toBe("FRIEND_CODE_REQUIRED")
   })
 
-  it("creates a listing with complete modifiers and triggers match notifications", async () => {
+  it("creates a listing with friendship requirement, modifiers and notifications", async () => {
     const user = await createUser()
     getServerSession.mockResolvedValueOnce({
       user: { id: user.id, ign: user.ign, role: user.role },
@@ -163,6 +164,7 @@ describe("POST /api/trades", () => {
     const { req, res } = createMocks({
       method: "POST",
       body: {
+        friendshipRequirement: "BEST",
         location: "Leigh town centre",
         notes: "Available evenings",
         offeredItems: [{
@@ -179,6 +181,7 @@ describe("POST /api/trades", () => {
 
     expect(res._getStatusCode()).toBe(201)
     const payload = JSON.parse(res._getData())
+    expect(payload.friendshipRequirement).toBe("BEST")
     expect(payload.items).toHaveLength(2)
     expect(payload.items[0]).toMatchObject({
       pokemonName: "Mewtwo",
@@ -189,10 +192,54 @@ describe("POST /api/trades", () => {
     })
     expect(syncWantedTradeNotificationsForListing).toHaveBeenCalledTimes(1)
 
+    const storedListing = await prisma.tradeListing.findUnique({
+      where: { id: payload.id },
+    })
+    expect(storedListing.friendshipRequirement).toBe("BEST")
+
     const createdAt = new Date(payload.createdAt)
     const expiresAt = new Date(payload.expiresAt)
     expect(expiresAt.getTime()).toBeGreaterThan(createdAt.getTime() + 27 * 86400000)
     expect(expiresAt.getTime()).toBeLessThan(createdAt.getTime() + 32 * 86400000)
+  })
+
+  it("defaults a missing friendship requirement to any level", async () => {
+    const user = await createUser()
+    getServerSession.mockResolvedValueOnce({
+      user: { id: user.id, ign: user.ign, role: user.role },
+    })
+    const { req, res } = createMocks({
+      method: "POST",
+      body: {
+        offeredItems: [{ pokemonName: "Pikachu" }],
+        wantedItems: [{ pokemonName: "Eevee" }],
+      },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(201)
+    expect(JSON.parse(res._getData()).friendshipRequirement).toBe("ANY")
+  })
+
+  it("rejects an invalid friendship requirement", async () => {
+    const user = await createUser()
+    getServerSession.mockResolvedValueOnce({
+      user: { id: user.id, ign: user.ign, role: user.role },
+    })
+    const { req, res } = createMocks({
+      method: "POST",
+      body: {
+        friendshipRequirement: "ULTRA_BEST",
+        offeredItems: [{ pokemonName: "Pikachu" }],
+        wantedItems: [{ pokemonName: "Eevee" }],
+      },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(400)
+    expect(JSON.parse(res._getData()).error).toContain("friendship requirement")
   })
 
   it("rejects a Pokémon marked as both XXL and XXS", async () => {

--- a/components/TradeListingForm.js
+++ b/components/TradeListingForm.js
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { TRADE_FRIENDSHIP_REQUIREMENTS } from "../lib/tradeUtils"
 
 const emptyItem = () => ({
   pokemonName: "",
@@ -143,6 +144,9 @@ export default function TradeListingForm({
   submitLabel = "Save listing",
   isSubmitting = false,
 }) {
+  const [friendshipRequirement, setFriendshipRequirement] = useState(
+    initialValue?.friendshipRequirement || "ANY",
+  )
   const [location, setLocation] = useState(initialValue?.location || "")
   const [notes, setNotes] = useState(initialValue?.notes || "")
   const [offeredItems, setOfferedItems] = useState(
@@ -154,7 +158,13 @@ export default function TradeListingForm({
 
   const handleSubmit = async (event) => {
     event.preventDefault()
-    await onSubmit({ location, notes, offeredItems, wantedItems })
+    await onSubmit({
+      friendshipRequirement,
+      location,
+      notes,
+      offeredItems,
+      wantedItems,
+    })
   }
 
   return (
@@ -174,6 +184,24 @@ export default function TradeListingForm({
       <section className="trade-form-section">
         <h2>Trade details</h2>
         <div className="stack trade-details-fields">
+          <label>
+            Friendship requirement
+            <select
+              value={friendshipRequirement}
+              onChange={(event) => setFriendshipRequirement(event.target.value)}
+            >
+              {TRADE_FRIENDSHIP_REQUIREMENTS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <p className="muted">
+            Choose the minimum friendship level you are willing to trade at, or restrict
+            the listing to Lucky Friends only.
+          </p>
+
           <label>
             General location
             <input

--- a/lib/tradeUtils.js
+++ b/lib/tradeUtils.js
@@ -2,6 +2,29 @@ import { formatFriendCode, normalizeFriendCode } from "./friendCode"
 
 export { formatFriendCode, normalizeFriendCode }
 
+export const TRADE_FRIENDSHIP_REQUIREMENTS = [
+  { value: "ANY", label: "Any friendship level" },
+  { value: "GOOD", label: "Good Friends or higher" },
+  { value: "GREAT", label: "Great Friends or higher" },
+  { value: "ULTRA", label: "Ultra Friends or higher" },
+  { value: "BEST", label: "Best Friends only" },
+  { value: "LUCKY", label: "Lucky Friends only" },
+]
+
+const TRADE_FRIENDSHIP_VALUES = new Set(
+  TRADE_FRIENDSHIP_REQUIREMENTS.map(({ value }) => value),
+)
+
+export const normalizeTradeFriendshipRequirement = (value = "ANY") => {
+  const normalized = String(value ?? "ANY").trim().toUpperCase()
+  return TRADE_FRIENDSHIP_VALUES.has(normalized) ? normalized : null
+}
+
+export const tradeFriendshipRequirementLabel = (value) =>
+  TRADE_FRIENDSHIP_REQUIREMENTS.find(
+    (option) => option.value === normalizeTradeFriendshipRequirement(value),
+  )?.label || TRADE_FRIENDSHIP_REQUIREMENTS[0].label
+
 const MAX_ITEMS_PER_SIDE = 20
 const MAX_POKEMON_NAME_LENGTH = 100
 const MAX_ITEM_NOTES_LENGTH = 250
@@ -13,7 +36,7 @@ const cleanText = (value, maxLength) =>
 
 export const addOneMonth = (value = new Date()) => {
   const source = new Date(value)
-  const result = new Date(source)
+  const result = new Date(value)
   const originalDay = result.getUTCDate()
 
   result.setUTCDate(1)
@@ -77,8 +100,17 @@ export const validateTradeListingPayload = (payload = {}) => {
   const wanted = normalizeItems(payload.wantedItems, "WANT")
   if (wanted.error) return wanted
 
+  const friendshipRequirement = normalizeTradeFriendshipRequirement(
+    payload.friendshipRequirement,
+  )
+
+  if (!friendshipRequirement) {
+    return { error: "Select a valid friendship requirement." }
+  }
+
   return {
     value: {
+      friendshipRequirement,
       location: cleanText(payload.location, MAX_LOCATION_LENGTH) || null,
       notes: cleanText(payload.notes, MAX_LISTING_NOTES_LENGTH) || null,
       items: [...offered.items, ...wanted.items],
@@ -97,6 +129,8 @@ export const serializeTradeListing = (listing) => {
       ign: listing.owner?.ign || "Unknown trainer",
       friendCode: normalizeFriendCode(ownerEntry?.code),
     },
+    friendshipRequirement:
+      normalizeTradeFriendshipRequirement(listing.friendshipRequirement) || "ANY",
     location: listing.location,
     notes: listing.notes,
     status: listing.status,

--- a/lib/tradeUtils.js
+++ b/lib/tradeUtils.js
@@ -36,7 +36,7 @@ const cleanText = (value, maxLength) =>
 
 export const addOneMonth = (value = new Date()) => {
   const source = new Date(value)
-  const result = new Date(value)
+  const result = new Date(source)
   const originalDay = result.getUTCDate()
 
   result.setUTCDate(1)

--- a/pages/api/trades/[id].js
+++ b/pages/api/trades/[id].js
@@ -79,9 +79,13 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: "Invalid listing status" })
     }
 
-    const hasListingContent = ["location", "notes", "offeredItems", "wantedItems"].some(
-      (key) => Object.prototype.hasOwnProperty.call(req.body || {}, key)
-    )
+    const hasListingContent = [
+      "friendshipRequirement",
+      "location",
+      "notes",
+      "offeredItems",
+      "wantedItems",
+    ].some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key))
 
     let data = { status: requestedStatus }
 
@@ -94,6 +98,7 @@ export default async function handler(req, res) {
 
       data = {
         ...data,
+        friendshipRequirement: validated.value.friendshipRequirement,
         location: validated.value.location,
         notes: validated.value.notes,
         items: {

--- a/pages/api/trades/index.js
+++ b/pages/api/trades/index.js
@@ -65,6 +65,7 @@ export default async function handler(req, res) {
     const listing = await prisma.tradeListing.create({
       data: {
         ownerId: tradeUser.id,
+        friendshipRequirement: validated.value.friendshipRequirement,
         location: validated.value.location,
         notes: validated.value.notes,
         status: "ACTIVE",

--- a/pages/trades/[id].js
+++ b/pages/trades/[id].js
@@ -11,6 +11,7 @@ import {
 import {
   formatFriendCode,
   serializeTradeListing,
+  tradeFriendshipRequirementLabel,
 } from "../../lib/tradeUtils"
 
 const attributeLabels = (item) => [
@@ -124,6 +125,10 @@ export default function TradeListingPage({ listing, viewer }) {
           <span className="entry-code">
             {formatFriendCode(listing.owner.friendCode) || "Unavailable"}
           </span>
+        </p>
+        <p>
+          <strong>Friendship requirement:</strong>{" "}
+          {tradeFriendshipRequirementLabel(listing.friendshipRequirement)}
         </p>
         {listing.location && (
           <p><strong>General location:</strong> {listing.location}</p>

--- a/pages/trades/[id]/edit.js
+++ b/pages/trades/[id]/edit.js
@@ -18,6 +18,7 @@ export default function EditTradeListingPage({ listing }) {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const initialValue = {
+    friendshipRequirement: listing.friendshipRequirement || "ANY",
     location: listing.location || "",
     notes: listing.notes || "",
     offeredItems: listing.items.filter((item) => item.direction === "OFFER"),

--- a/pages/trades/index.js
+++ b/pages/trades/index.js
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { useState } from "react"
 import { useRouter } from "next/router"
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "../api/auth/[...nextauth]"
@@ -8,7 +9,11 @@ import {
   purgeExpiredTradeListings,
   tradeListingInclude,
 } from "../../lib/tradeServer"
-import { serializeTradeListing } from "../../lib/tradeUtils"
+import {
+  serializeTradeListing,
+  TRADE_FRIENDSHIP_REQUIREMENTS,
+  tradeFriendshipRequirementLabel,
+} from "../../lib/tradeUtils"
 
 const itemNames = (listing, direction) =>
   listing.items
@@ -42,6 +47,9 @@ function ListingCard({ listing, mine = false, onClose }) {
         </div>
       </div>
 
+      <p className="muted">
+        Friendship requirement: {tradeFriendshipRequirementLabel(listing.friendshipRequirement)}
+      </p>
       {listing.location && <p className="muted">Location: {listing.location}</p>}
       <p className="muted">
         Expires {new Date(listing.expiresAt).toLocaleDateString("en-GB")}
@@ -68,6 +76,12 @@ function ListingCard({ listing, mine = false, onClose }) {
 
 export default function TradesPage({ listings, myListings }) {
   const router = useRouter()
+  const [friendshipFilter, setFriendshipFilter] = useState("ALL")
+  const visibleListings = friendshipFilter === "ALL"
+    ? listings
+    : listings.filter(
+        (listing) => listing.friendshipRequirement === friendshipFilter,
+      )
 
   const closeListing = async (listingId) => {
     if (!window.confirm("Close this listing? It will no longer appear in active trades.")) {
@@ -108,14 +122,35 @@ export default function TradesPage({ listings, myListings }) {
         </div>
       </div>
 
+      <div className="card">
+        <label>
+          Filter active listings by friendship requirement
+          <select
+            value={friendshipFilter}
+            onChange={(event) => setFriendshipFilter(event.target.value)}
+          >
+            <option value="ALL">All friendship requirements</option>
+            {TRADE_FRIENDSHIP_REQUIREMENTS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
       <section>
         <h2 className="trade-page-heading">Active listings</h2>
-        {listings.length === 0 ? (
+        {visibleListings.length === 0 ? (
           <div className="card">
-            <p className="muted">There are no active trade listings yet.</p>
+            <p className="muted">
+              {listings.length === 0
+                ? "There are no active trade listings yet."
+                : "No active listings match that friendship requirement."}
+            </p>
           </div>
         ) : (
-          listings.map((listing) => (
+          visibleListings.map((listing) => (
             <ListingCard key={listing.id} listing={listing} />
           ))
         )}

--- a/prisma/migrations/20260802130500_add_trade_friendship_requirement/migration.sql
+++ b/prisma/migrations/20260802130500_add_trade_friendship_requirement/migration.sql
@@ -1,0 +1,4 @@
+-- Add a listing-level friendship requirement.
+-- Existing listings remain available to any friendship level.
+ALTER TABLE "TradeListing"
+ADD COLUMN "friendshipRequirement" TEXT NOT NULL DEFAULT 'ANY';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,17 +54,18 @@ model PokedexEntry {
 }
 
 model TradeListing {
-  id            Int                 @id @default(autoincrement())
-  ownerId       Int
-  owner         User                @relation(fields: [ownerId], references: [id], onDelete: Cascade)
-  location      String?
-  notes         String?
-  status        String              @default("ACTIVE")
-  createdAt     DateTime            @default(now())
-  updatedAt     DateTime            @updatedAt
-  expiresAt     DateTime
-  items         TradeListingItem[]
-  notifications TradeNotification[]
+  id                    Int                 @id @default(autoincrement())
+  ownerId               Int
+  owner                 User                @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  friendshipRequirement String              @default("ANY")
+  location              String?
+  notes                 String?
+  status                String              @default("ACTIVE")
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
+  expiresAt             DateTime
+  items                 TradeListingItem[]
+  notifications         TradeNotification[]
 
   @@index([status, expiresAt])
   @@index([ownerId, createdAt])


### PR DESCRIPTION
## What changed

- adds a listing-level friendship requirement to trade listings
- supports Any, Good, Great, Ultra, Best and Lucky Friends only
- defaults existing and unspecified listings to Any friendship level
- adds the selector to create and edit forms
- shows the requirement on listing cards and listing details
- adds an active-listing filter for friendship requirement
- validates allowed values server-side and serializes them consistently
- adds API regression coverage for explicit, default and invalid requirements

## Data migration

Adds `TradeListing.friendshipRequirement` with a non-null `ANY` default, so existing listings keep their current behaviour.

## Deployment

Run `npm run db:deploy` before rebuilding and restarting the service.

## Validation

The Validate workflow will run dependency audits, ESLint, Jest and the production build.