### PR TITLE
Allow offer-only and wanted-only trade listings

### DIFF
--- a/__tests__/api/trades.test.js
+++ b/__tests__/api/trades.test.js
@@ -115,6 +115,19 @@ const createUser = async ({ withFriendCode = true } = {}) => {
   return user
 }
 
+const blankItem = () => ({
+  pokemonName: "",
+  shiny: false,
+  lucky: false,
+  xxl: false,
+  xxs: false,
+  costume: false,
+  background: false,
+  dynamax: false,
+  gigantamax: false,
+  notes: "",
+})
+
 beforeAll(async () => {
   await ensureSchema()
 })
@@ -201,6 +214,78 @@ describe("POST /api/trades", () => {
     const expiresAt = new Date(payload.expiresAt)
     expect(expiresAt.getTime()).toBeGreaterThan(createdAt.getTime() + 27 * 86400000)
     expect(expiresAt.getTime()).toBeLessThan(createdAt.getTime() + 32 * 86400000)
+  })
+
+  it("creates an offer-only listing and ignores the blank wanted row", async () => {
+    const user = await createUser()
+    getServerSession.mockResolvedValueOnce({
+      user: { id: user.id, ign: user.ign, role: user.role },
+    })
+
+    const { req, res } = createMocks({
+      method: "POST",
+      body: {
+        offeredItems: [{ pokemonName: "Pikachu" }],
+        wantedItems: [blankItem()],
+      },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(201)
+    const payload = JSON.parse(res._getData())
+    expect(payload.items).toHaveLength(1)
+    expect(payload.items[0]).toMatchObject({
+      direction: "OFFER",
+      pokemonName: "Pikachu",
+    })
+  })
+
+  it("creates a wanted-only listing and ignores the blank offered row", async () => {
+    const user = await createUser()
+    getServerSession.mockResolvedValueOnce({
+      user: { id: user.id, ign: user.ign, role: user.role },
+    })
+
+    const { req, res } = createMocks({
+      method: "POST",
+      body: {
+        offeredItems: [blankItem()],
+        wantedItems: [{ pokemonName: "Eevee" }],
+      },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(201)
+    const payload = JSON.parse(res._getData())
+    expect(payload.items).toHaveLength(1)
+    expect(payload.items[0]).toMatchObject({
+      direction: "WANT",
+      pokemonName: "Eevee",
+    })
+  })
+
+  it("rejects a listing when both sides are blank", async () => {
+    const user = await createUser()
+    getServerSession.mockResolvedValueOnce({
+      user: { id: user.id, ign: user.ign, role: user.role },
+    })
+
+    const { req, res } = createMocks({
+      method: "POST",
+      body: {
+        offeredItems: [blankItem()],
+        wantedItems: [blankItem()],
+      },
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(400)
+    expect(JSON.parse(res._getData()).error).toContain(
+      "at least one Pokémon you are offering or want",
+    )
   })
 
   it("defaults a missing friendship requirement to any level", async () => {

--- a/components/TradeListingForm.js
+++ b/components/TradeListingForm.js
@@ -35,14 +35,21 @@ function TradeItemsEditor({ title, items, onChange }) {
   }
 
   const removeItem = (index) => {
-    if (items.length === 1) return
+    if (items.length === 1) {
+      onChange([emptyItem()])
+      return
+    }
+
     onChange(items.filter((_, itemIndex) => itemIndex !== index))
   }
 
   return (
     <section className="trade-form-section">
       <div className="trade-section-header">
-        <h2>{title}</h2>
+        <div>
+          <h2>{title}</h2>
+          <p className="muted">Optional — leave this section blank when it does not apply.</p>
+        </div>
         <button
           type="button"
           className="secondary-button"
@@ -57,15 +64,13 @@ function TradeItemsEditor({ title, items, onChange }) {
           <div className="trade-item-editor" key={index}>
             <div className="trade-section-header">
               <strong>Pokémon {index + 1}</strong>
-              {items.length > 1 && (
-                <button
-                  type="button"
-                  className="danger compact-button"
-                  onClick={() => removeItem(index)}
-                >
-                  Remove
-                </button>
-              )}
+              <button
+                type="button"
+                className="danger compact-button"
+                onClick={() => removeItem(index)}
+              >
+                Clear
+              </button>
             </div>
 
             <label>
@@ -75,7 +80,6 @@ function TradeItemsEditor({ title, items, onChange }) {
                 value={item.pokemonName}
                 onChange={(event) => updateItem(index, { pokemonName: event.target.value })}
                 maxLength={100}
-                required
               />
             </label>
 
@@ -169,6 +173,12 @@ export default function TradeListingForm({
 
   return (
     <form className="trade-listing-form" onSubmit={handleSubmit}>
+      <div className="card">
+        <p className="muted">
+          Add Pokémon to the offered list, the wanted list, or both. Only one side is required.
+        </p>
+      </div>
+
       <TradeItemsEditor
         title="Pokémon offered"
         items={offeredItems}

--- a/lib/tradeUtils.js
+++ b/lib/tradeUtils.js
@@ -30,6 +30,16 @@ const MAX_POKEMON_NAME_LENGTH = 100
 const MAX_ITEM_NOTES_LENGTH = 250
 const MAX_LOCATION_LENGTH = 120
 const MAX_LISTING_NOTES_LENGTH = 1000
+const ITEM_FLAGS = [
+  "shiny",
+  "lucky",
+  "xxl",
+  "xxs",
+  "costume",
+  "background",
+  "dynamax",
+  "gigantamax",
+]
 
 const cleanText = (value, maxLength) =>
   String(value ?? "").trim().slice(0, maxLength)
@@ -51,8 +61,8 @@ export const addOneMonth = (value = new Date()) => {
 }
 
 const normalizeItems = (items, direction) => {
-  if (!Array.isArray(items) || items.length === 0) {
-    return { error: `Add at least one Pokémon you ${direction === "OFFER" ? "are offering" : "want"}.` }
+  if (!Array.isArray(items)) {
+    return { items: [] }
   }
 
   if (items.length > MAX_ITEMS_PER_SIDE) {
@@ -63,9 +73,19 @@ const normalizeItems = (items, direction) => {
 
   for (const item of items) {
     const pokemonName = cleanText(item?.pokemonName, MAX_POKEMON_NAME_LENGTH)
+    const notes = cleanText(item?.notes, MAX_ITEM_NOTES_LENGTH)
+    const hasItemDetails = Boolean(
+      pokemonName || notes || ITEM_FLAGS.some((flag) => Boolean(item?.[flag])),
+    )
+
+    // The form keeps one empty row visible on each side. Ignore untouched rows so
+    // a listing may contain offers only, wanted Pokémon only, or both.
+    if (!hasItemDetails) {
+      continue
+    }
 
     if (!pokemonName) {
-      return { error: "Every trade item needs a Pokémon name." }
+      return { error: "Every configured trade item needs a Pokémon name." }
     }
 
     const xxl = Boolean(item?.xxl)
@@ -86,7 +106,7 @@ const normalizeItems = (items, direction) => {
       background: Boolean(item?.background),
       dynamax: Boolean(item?.dynamax),
       gigantamax: Boolean(item?.gigantamax),
-      notes: cleanText(item?.notes, MAX_ITEM_NOTES_LENGTH) || null,
+      notes: notes || null,
     })
   }
 
@@ -99,6 +119,12 @@ export const validateTradeListingPayload = (payload = {}) => {
 
   const wanted = normalizeItems(payload.wantedItems, "WANT")
   if (wanted.error) return wanted
+
+  const items = [...offered.items, ...wanted.items]
+
+  if (items.length === 0) {
+    return { error: "Add at least one Pokémon you are offering or want." }
+  }
 
   const friendshipRequirement = normalizeTradeFriendshipRequirement(
     payload.friendshipRequirement,
@@ -113,7 +139,7 @@ export const validateTradeListingPayload = (payload = {}) => {
       friendshipRequirement,
       location: cleanText(payload.location, MAX_LOCATION_LENGTH) || null,
       notes: cleanText(payload.notes, MAX_LISTING_NOTES_LENGTH) || null,
-      items: [...offered.items, ...wanted.items],
+      items,
     },
   }
 }

--- a/pages/trades/[id].js
+++ b/pages/trades/[id].js
@@ -29,27 +29,31 @@ function TradeItemList({ title, items }) {
   return (
     <section className="card">
       <h2>{title}</h2>
-      <div className="trade-items">
-        {items.map((item) => {
-          const attributes = attributeLabels(item)
+      {items.length === 0 ? (
+        <p className="muted">None specified.</p>
+      ) : (
+        <div className="trade-items">
+          {items.map((item) => {
+            const attributes = attributeLabels(item)
 
-          return (
-            <div className="trade-item" key={item.id}>
-              <strong>{item.pokemonName}</strong>
-              {attributes.length > 0 && (
-                <div className="trade-attributes">
-                  {attributes.map((attribute) => (
-                    <span className="trade-attribute" key={attribute}>
-                      {attribute}
-                    </span>
-                  ))}
-                </div>
-              )}
-              {item.notes && <p className="muted">{item.notes}</p>}
-            </div>
-          )
-        })}
-      </div>
+            return (
+              <div className="trade-item" key={item.id}>
+                <strong>{item.pokemonName}</strong>
+                {attributes.length > 0 && (
+                  <div className="trade-attributes">
+                    {attributes.map((attribute) => (
+                      <span className="trade-attribute" key={attribute}>
+                        {attribute}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {item.notes && <p className="muted">{item.notes}</p>}
+              </div>
+            )
+          })}
+        </div>
+      )}
     </section>
   )
 }

--- a/pages/trades/index.js
+++ b/pages/trades/index.js
@@ -15,11 +15,13 @@ import {
   tradeFriendshipRequirementLabel,
 } from "../../lib/tradeUtils"
 
-const itemNames = (listing, direction) =>
-  listing.items
+const itemNames = (listing, direction) => {
+  const names = listing.items
     .filter((item) => item.direction === direction)
     .map((item) => item.pokemonName)
-    .join(", ")
+
+  return names.length > 0 ? names.join(", ") : "None specified"
+}
 
 function ListingCard({ listing, mine = false, onClose }) {
   return (


### PR DESCRIPTION
## What changed

- makes offered and wanted Pokémon independent sections
- allows offer-only, wanted-only, or two-sided trade listings
- ignores untouched blank form rows
- rejects only listings where both sides are empty
- removes browser-required validation from each visible placeholder row
- adds a clear action for the remaining row on either side
- displays `None specified` for an unused side on cards and listing details
- adds regression tests for offer-only, wanted-only, both-sided, and empty listings

## Scope

No database migration is required. Existing listings are unchanged.

## Validation

The Validate workflow will run dependency audits, ESLint, Jest, and the production build.