### PR TITLE
Add Pokédex costs, buddy rewards and availability overrides

### DIFF
--- a/__tests__/lib/pokedexCatalog.test.js
+++ b/__tests__/lib/pokedexCatalog.test.js
@@ -3,7 +3,7 @@ const {
   regionForDexNumber,
 } = require("../../lib/pokedexCatalog");
 
-describe("POGOAPI Pokédex catalog", () => {
+describe("Pokédex catalog", () => {
   const names = Object.fromEntries(
     Array.from({ length: 135 }, (_, index) => {
       const id = index + 1;
@@ -66,8 +66,38 @@ describe("POGOAPI Pokédex catalog", () => {
     },
   ];
 
+  const buddyDistances = {
+    3: [
+      { pokemon_id: 1, pokemon_name: "Bulbasaur", form: "Normal", distance: 3 },
+      { pokemon_id: 1, pokemon_name: "Bulbasaur", form: "Shadow", distance: 5 },
+      { pokemon_id: 2, pokemon_name: "Ivysaur", form: "Normal", distance: 3 },
+    ],
+    5: [
+      { pokemon_id: 3, pokemon_name: "Venusaur", form: "Mega", distance: 5 },
+      { pokemon_id: 68, pokemon_name: "Machamp", form: "Normal", distance: 5 },
+    ],
+  };
+
+  const pvpokePokemon = [
+    { dex: 1, speciesName: "Bulbasaur", speciesId: "bulbasaur", thirdMoveCost: 10000 },
+    { dex: 1, speciesName: "Bulbasaur (Shadow)", speciesId: "bulbasaur_shadow", tags: ["shadow"], thirdMoveCost: 100000 },
+    { dex: 2, speciesName: "Ivysaur", speciesId: "ivysaur", thirdMoveCost: 50000 },
+    { dex: 3, speciesName: "Venusaur", speciesId: "venusaur", thirdMoveCost: 75000 },
+    { dex: 3, speciesName: "Venusaur (Mega)", speciesId: "venusaur_mega", tags: ["mega"], thirdMoveCost: 10000 },
+    { dex: 68, speciesName: "Machamp", speciesId: "machamp", thirdMoveCost: 100000 },
+  ];
+
+  const buildCatalog = () =>
+    buildPokedexCatalog(
+      names,
+      types,
+      evolutions,
+      buddyDistances,
+      pvpokePokemon
+    );
+
   test("creates previous and next links by evolution stage", () => {
-    const catalog = buildPokedexCatalog(names, types, evolutions);
+    const catalog = buildCatalog();
 
     expect(catalog.pokemon[1].previous).toEqual([]);
     expect(catalog.pokemon[1].next).toEqual([
@@ -88,7 +118,7 @@ describe("POGOAPI Pokédex catalog", () => {
   });
 
   test("keeps every branch of a branching evolution", () => {
-    const catalog = buildPokedexCatalog(names, types, evolutions);
+    const catalog = buildCatalog();
     expect(catalog.pokemon[133].next).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ pokemonId: 134, candyRequired: 25 }),
@@ -98,7 +128,7 @@ describe("POGOAPI Pokédex catalog", () => {
   });
 
   test("keeps the zero Candy after trade flag in both directions", () => {
-    const catalog = buildPokedexCatalog(names, types, evolutions);
+    const catalog = buildCatalog();
 
     expect(catalog.pokemon[67].next).toEqual([
       expect.objectContaining({
@@ -116,9 +146,20 @@ describe("POGOAPI Pokédex catalog", () => {
     ]);
   });
 
-  test("uses the normal form typing for a National Dex card", () => {
-    const catalog = buildPokedexCatalog(names, types, evolutions);
+  test("uses normal-form typing and buddy distance", () => {
+    const catalog = buildCatalog();
     expect(catalog.pokemon[3].types).toEqual(["Grass", "Poison"]);
+    expect(catalog.pokemon[1].buddyDistance).toBe(3);
+    expect(catalog.pokemon[3].buddyDistance).toBe(5);
+  });
+
+  test("maps all standard second charged-move cost tiers", () => {
+    const catalog = buildCatalog();
+
+    expect(catalog.pokemon[1].secondMoveCost).toEqual({ stardust: 10000, candy: 25 });
+    expect(catalog.pokemon[2].secondMoveCost).toEqual({ stardust: 50000, candy: 50 });
+    expect(catalog.pokemon[3].secondMoveCost).toEqual({ stardust: 75000, candy: 75 });
+    expect(catalog.pokemon[68].secondMoveCost).toEqual({ stardust: 100000, candy: 100 });
   });
 
   test("keeps the existing regional ordering rules", () => {

--- a/__tests__/lib/pokemonAvailability.test.js
+++ b/__tests__/lib/pokemonAvailability.test.js
@@ -1,0 +1,37 @@
+const {
+  applyPokemonAvailabilityOverrides,
+  sortPokemonAvailabilityRows,
+} = require("../../lib/pokemonAvailability");
+
+describe("Pokémon availability overrides", () => {
+  test("applies released and unreleased overrides to the POGOAPI set", () => {
+    expect(
+      applyPokemonAvailabilityOverrides([1, 2, 3], [
+        { dexNumber: 2, released: false },
+        { dexNumber: 4, released: true },
+      ])
+    ).toEqual([1, 3, 4]);
+  });
+
+  test("sorts effective unreleased Pokémon first", () => {
+    const rows = [
+      { dexNumber: 1, effectiveReleased: true },
+      { dexNumber: 3, effectiveReleased: false },
+      { dexNumber: 2, effectiveReleased: false },
+    ];
+
+    expect(
+      sortPokemonAvailabilityRows(rows, "unreleased").map(
+        (row) => row.dexNumber
+      )
+    ).toEqual([2, 3, 1]);
+    expect(
+      sortPokemonAvailabilityRows(rows, "released").map(
+        (row) => row.dexNumber
+      )
+    ).toEqual([1, 2, 3]);
+    expect(
+      sortPokemonAvailabilityRows(rows, "dex").map((row) => row.dexNumber)
+    ).toEqual([1, 2, 3]);
+  });
+});

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -175,6 +175,9 @@ export default function Navbar() {
                     <Link href="/admin" className="nav-item nav-subitem">
                       Admin Panel
                     </Link>
+                    <Link href="/admin/pokedex" className="nav-item nav-subitem">
+                      Pokédex Availability
+                    </Link>
                     <Link href="/admin/events" className="nav-item nav-subitem">
                       Event Feed
                     </Link>

--- a/lib/pokedexCatalog.js
+++ b/lib/pokedexCatalog.js
@@ -14,6 +14,19 @@ const REGION_DEFINITIONS = [
 
 const IGNORED_EVOLUTION_FORMS = new Set(["shadow", "purified"]);
 const NORMAL_FORMS = new Set(["", "normal", "default"]);
+const SECOND_MOVE_CANDY_BY_STARDUST = new Map([
+  [10_000, 25],
+  [50_000, 50],
+  [75_000, 75],
+  [100_000, 100],
+]);
+const NON_STANDARD_PVPOKE_FORMS = [
+  "shadow",
+  "mega",
+  "primal",
+  "gmax",
+  "eternamax",
+];
 
 function optionalString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -90,6 +103,92 @@ function buildTypesByPokemon(typeRows) {
   return typesByPokemon;
 }
 
+function groupedRows(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return [];
+  }
+
+  return Object.values(payload).flatMap((rows) =>
+    Array.isArray(rows) ? rows : []
+  );
+}
+
+function buildBuddyDistanceByPokemon(payload) {
+  const rowsByPokemon = new Map();
+
+  for (const row of groupedRows(payload)) {
+    const pokemonId = Number(row?.pokemon_id);
+    if (!Number.isInteger(pokemonId)) continue;
+
+    const current = rowsByPokemon.get(pokemonId) || [];
+    current.push(row);
+    rowsByPokemon.set(pokemonId, current);
+  }
+
+  const distancesByPokemon = new Map();
+  for (const [pokemonId, rows] of rowsByPokemon.entries()) {
+    const preferred = [...rows].sort(
+      (left, right) => formPreference(left) - formPreference(right)
+    )[0];
+    const distance = Number(preferred?.distance);
+    if (Number.isFinite(distance) && distance > 0) {
+      distancesByPokemon.set(pokemonId, distance);
+    }
+  }
+
+  return distancesByPokemon;
+}
+
+function pvpokeFormPreference(row) {
+  const speciesId = String(row?.speciesId || "").toLowerCase();
+  const speciesName = String(row?.speciesName || "").toLowerCase();
+  const tags = Array.isArray(row?.tags)
+    ? row.tags.map((tag) => String(tag).toLowerCase())
+    : [];
+
+  let score = speciesName.includes("(") ? 10 : 0;
+  for (const form of NON_STANDARD_PVPOKE_FORMS) {
+    if (
+      speciesId.includes(`_${form}`) ||
+      speciesName.includes(`(${form}`) ||
+      tags.includes(form)
+    ) {
+      score += 100;
+    }
+  }
+
+  return score;
+}
+
+function buildSecondMoveCostByPokemon(rows) {
+  const rowsByPokemon = new Map();
+
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const pokemonId = Number(row?.dex);
+    if (!Number.isInteger(pokemonId)) continue;
+
+    const current = rowsByPokemon.get(pokemonId) || [];
+    current.push(row);
+    rowsByPokemon.set(pokemonId, current);
+  }
+
+  const costsByPokemon = new Map();
+  for (const [pokemonId, pokemonRows] of rowsByPokemon.entries()) {
+    const preferred = [...pokemonRows].sort(
+      (left, right) => pvpokeFormPreference(left) - pvpokeFormPreference(right)
+    )[0];
+    const stardust = Number(preferred?.thirdMoveCost);
+    if (!Number.isFinite(stardust) || stardust <= 0) continue;
+
+    costsByPokemon.set(pokemonId, {
+      stardust,
+      candy: SECOND_MOVE_CANDY_BY_STARDUST.get(stardust) ?? null,
+    });
+  }
+
+  return costsByPokemon;
+}
+
 function relationshipKey(relationship) {
   return [
     relationship.pokemonId,
@@ -118,18 +217,32 @@ function shouldIncludeEvolutionRow(row) {
   return !IGNORED_EVOLUTION_FORMS.has(form);
 }
 
-function buildPokedexCatalog(namesPayload, typeRows, evolutionRows) {
+function buildPokedexCatalog(
+  namesPayload,
+  typeRows,
+  evolutionRows,
+  buddyDistancePayload,
+  pvpokePokemonRows
+) {
   const pokemonList = normalisePokemonNames(namesPayload);
   const namesById = new Map(
     pokemonList.map((pokemon) => [pokemon.dexNumber, pokemon.name])
   );
   const typesByPokemon = buildTypesByPokemon(typeRows);
+  const buddyDistanceByPokemon = buildBuddyDistanceByPokemon(
+    buddyDistancePayload
+  );
+  const secondMoveCostByPokemon = buildSecondMoveCostByPokemon(
+    pvpokePokemonRows
+  );
   const pokemon = Object.fromEntries(
     pokemonList.map(({ dexNumber, name }) => [
       dexNumber,
       {
         name,
         types: typesByPokemon.get(dexNumber) || [],
+        buddyDistance: buddyDistanceByPokemon.get(dexNumber) ?? null,
+        secondMoveCost: secondMoveCostByPokemon.get(dexNumber) ?? null,
         previous: [],
         next: [],
       },
@@ -202,7 +315,10 @@ function buildPokedexCatalog(namesPayload, typeRows, evolutionRows) {
 
 module.exports = {
   REGION_DEFINITIONS,
+  SECOND_MOVE_CANDY_BY_STARDUST,
+  buildBuddyDistanceByPokemon,
   buildPokedexCatalog,
+  buildSecondMoveCostByPokemon,
   normalisePokemonNames,
   prettyForm,
   regionForDexNumber,

--- a/lib/pokedexCatalogCache.js
+++ b/lib/pokedexCatalogCache.js
@@ -6,15 +6,22 @@ const {
 } = require("./pogoApiHashCache");
 const { buildPokedexCatalog } = require("./pokedexCatalog");
 
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
 const CACHE_TTL_MS = HASH_CACHE_TTL_MS;
 const REQUEST_TIMEOUT_MS = 15_000;
 const MIN_EXPECTED_POKEMON = 100;
-const FILES = [
+const POGOAPI_FILES = [
   "pokemon_names.json",
   "pokemon_types.json",
   "pokemon_evolutions.json",
+  "pokemon_buddy_distances.json",
 ];
+const PVPOKE_FILE_KEY = "pvpoke_pokemon.json";
+const SOURCE_KEYS = [...POGOAPI_FILES, PVPOKE_FILE_KEY];
+const PVPOKE_CONTENTS_API_URL =
+  "https://api.github.com/repos/pvpoke/pvpoke/contents/src/data/gamemaster/pokemon.json?ref=master";
+const PVPOKE_RAW_URL =
+  "https://raw.githubusercontent.com/pvpoke/pvpoke/master/src/data/gamemaster/pokemon.json";
 
 const memoryCaches = new Map();
 const refreshPromises = new Map();
@@ -62,7 +69,7 @@ async function readCache(filePath) {
   }
 }
 
-async function fetchJson(url) {
+async function fetchJson(url, extraHeaders = {}) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
@@ -71,12 +78,13 @@ async function fetchJson(url) {
       headers: {
         Accept: "application/json",
         "User-Agent": "LEIGHPOGO pokedex-catalog-cache",
+        ...extraHeaders,
       },
       signal: controller.signal,
     });
 
     if (!response.ok) {
-      throw new Error(`POGOAPI request failed with status ${response.status}.`);
+      throw new Error(`Catalog source request failed with status ${response.status}.`);
     }
 
     return response.json();
@@ -105,15 +113,15 @@ async function writeCache(filePath, cache, strictWrite) {
 }
 
 function hashesMatch(left, right) {
-  return FILES.every(
-    (filename) => left?.[filename] && left[filename] === right?.[filename]
+  return SOURCE_KEYS.every(
+    (sourceKey) => left?.[sourceKey] && left[sourceKey] === right?.[sourceKey]
   );
 }
 
-async function resolveSources(existingCache) {
+async function resolvePogoApiSources(existingCache) {
   try {
     const entries = await Promise.all(
-      FILES.map((filename) => getPogoApiFileHash(filename))
+      POGOAPI_FILES.map((filename) => getPogoApiFileHash(filename))
     );
 
     return {
@@ -137,16 +145,62 @@ async function resolveSources(existingCache) {
 
     return {
       sourceHashes: Object.fromEntries(
-        FILES.map((filename) => [filename, null])
+        POGOAPI_FILES.map((filename) => [filename, null])
       ),
       urls: Object.fromEntries(
-        FILES.map((filename) => [
+        POGOAPI_FILES.map((filename) => [
           filename,
           `https://pogoapi.net/api/v1/${filename}`,
         ])
       ),
     };
   }
+}
+
+async function resolvePvpokeSource(existingCache) {
+  try {
+    const metadata = await fetchJson(PVPOKE_CONTENTS_API_URL, {
+      Accept: "application/vnd.github+json",
+    });
+    if (!metadata?.sha || !metadata?.download_url) {
+      throw new Error("PvPoke returned invalid file metadata.");
+    }
+
+    return {
+      sourceHashes: { [PVPOKE_FILE_KEY]: metadata.sha },
+      urls: { [PVPOKE_FILE_KEY]: metadata.download_url },
+    };
+  } catch (error) {
+    if (existingCache) throw error;
+
+    console.warn(
+      "Unable to check the initial PvPoke Pokémon data hash; downloading the file directly",
+      error
+    );
+
+    return {
+      sourceHashes: { [PVPOKE_FILE_KEY]: null },
+      urls: { [PVPOKE_FILE_KEY]: PVPOKE_RAW_URL },
+    };
+  }
+}
+
+async function resolveSources(existingCache) {
+  const [pogoApiSources, pvpokeSource] = await Promise.all([
+    resolvePogoApiSources(existingCache),
+    resolvePvpokeSource(existingCache),
+  ]);
+
+  return {
+    sourceHashes: {
+      ...pogoApiSources.sourceHashes,
+      ...pvpokeSource.sourceHashes,
+    },
+    urls: {
+      ...pogoApiSources.urls,
+      ...pvpokeSource.urls,
+    },
+  };
 }
 
 async function refreshPokedexCatalog(existingCache, options) {
@@ -169,8 +223,14 @@ async function refreshPokedexCatalog(existingCache, options) {
     return unchangedCache;
   }
 
-  const [pokemonNames, pokemonTypes, pokemonEvolutions] = await Promise.all(
-    FILES.map((filename) => fetchJson(sources.urls[filename]))
+  const [
+    pokemonNames,
+    pokemonTypes,
+    pokemonEvolutions,
+    pokemonBuddyDistances,
+    pvpokePokemon,
+  ] = await Promise.all(
+    SOURCE_KEYS.map((sourceKey) => fetchJson(sources.urls[sourceKey]))
   );
 
   const refreshedCache = validateCache({
@@ -180,12 +240,14 @@ async function refreshPokedexCatalog(existingCache, options) {
     data: buildPokedexCatalog(
       pokemonNames,
       pokemonTypes,
-      pokemonEvolutions
+      pokemonEvolutions,
+      pokemonBuddyDistances,
+      pvpokePokemon
     ),
   });
 
   if (!refreshedCache) {
-    throw new Error("POGOAPI returned an invalid Pokédex catalog payload.");
+    throw new Error("The catalog sources returned an invalid Pokédex payload.");
   }
 
   await writeCache(options.cachePath, refreshedCache, options.strictWrite);

--- a/lib/pokemonAvailability.js
+++ b/lib/pokemonAvailability.js
@@ -1,0 +1,41 @@
+function normaliseDexNumber(value) {
+  const dexNumber = Number(value);
+  return Number.isInteger(dexNumber) && dexNumber > 0 ? dexNumber : null;
+}
+
+function applyPokemonAvailabilityOverrides(baseDexNumbers, overrides) {
+  const released = new Set(
+    (Array.isArray(baseDexNumbers) ? baseDexNumbers : [])
+      .map(normaliseDexNumber)
+      .filter((dexNumber) => dexNumber !== null)
+  );
+
+  for (const override of Array.isArray(overrides) ? overrides : []) {
+    const dexNumber = normaliseDexNumber(override?.dexNumber);
+    if (dexNumber === null || typeof override?.released !== "boolean") continue;
+
+    if (override.released) released.add(dexNumber);
+    else released.delete(dexNumber);
+  }
+
+  return [...released].sort((left, right) => left - right);
+}
+
+function sortPokemonAvailabilityRows(rows, sort = "dex") {
+  const values = Array.isArray(rows) ? [...rows] : [];
+  const statusDirection = sort === "unreleased" ? 1 : sort === "released" ? -1 : 0;
+
+  return values.sort((left, right) => {
+    if (statusDirection !== 0 && left.effectiveReleased !== right.effectiveReleased) {
+      return left.effectiveReleased ? statusDirection : -statusDirection;
+    }
+
+    return Number(left.dexNumber) - Number(right.dexNumber);
+  });
+}
+
+module.exports = {
+  applyPokemonAvailabilityOverrides,
+  normaliseDexNumber,
+  sortPokemonAvailabilityRows,
+};

--- a/pages/admin/pokedex.js
+++ b/pages/admin/pokedex.js
@@ -1,0 +1,343 @@
+import Link from "next/link"
+import { getServerSession } from "next-auth/next"
+import { useEffect, useMemo, useState } from "react"
+import { authOptions } from "../api/auth/[...nextauth]"
+
+const { applyPokemonAvailabilityOverrides, sortPokemonAvailabilityRows } = require("../../lib/pokemonAvailability")
+
+function overrideValue(override) {
+  if (!override) return "auto"
+  return override.released ? "released" : "unreleased"
+}
+
+export default function AdminPokedexAvailability() {
+  const [catalog, setCatalog] = useState(null)
+  const [overrides, setOverrides] = useState([])
+  const [drafts, setDrafts] = useState({})
+  const [sort, setSort] = useState("unreleased")
+  const [query, setQuery] = useState("")
+  const [onlyMismatches, setOnlyMismatches] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [savingDex, setSavingDex] = useState(null)
+  const [message, setMessage] = useState("")
+
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true)
+      setError("")
+      try {
+        const [catalogResponse, overridesResponse] = await Promise.all([
+          fetch("/api/pokedex-catalog"),
+          fetch("/api/admin/pokemon-availability-overrides"),
+        ])
+        const [catalogData, overridesData] = await Promise.all([
+          catalogResponse.json(),
+          overridesResponse.json(),
+        ])
+
+        if (!catalogResponse.ok) {
+          throw new Error(catalogData.error || "Unable to load Pokédex data")
+        }
+        if (!overridesResponse.ok) {
+          throw new Error(overridesData.error || "Unable to load overrides")
+        }
+
+        setCatalog(catalogData)
+        setOverrides(overridesData.overrides || [])
+        setDrafts(
+          Object.fromEntries(
+            (overridesData.overrides || []).map((override) => [
+              override.dexNumber,
+              { status: overrideValue(override), note: override.note || "" },
+            ])
+          )
+        )
+      } catch (loadError) {
+        setError(loadError.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadData()
+  }, [])
+
+  const rows = useMemo(() => {
+    if (!catalog) return []
+
+    const baseReleased =
+      catalog.pogoApiReleasedDexNumbers || catalog.releasedDexNumbers || []
+    const effectiveReleased = new Set(
+      applyPokemonAvailabilityOverrides(baseReleased, overrides)
+    )
+    const baseSet = new Set(baseReleased.map(Number))
+    const overrideMap = new Map(
+      overrides.map((override) => [override.dexNumber, override])
+    )
+    const normalisedQuery = query.trim().toLowerCase()
+
+    const values = catalog.regions.flatMap((region) =>
+      region.pokemon.map((pokemon) => {
+        const override = overrideMap.get(pokemon.dexNumber) || null
+        const pogoApiReleased = baseSet.has(pokemon.dexNumber)
+        const effective = effectiveReleased.has(pokemon.dexNumber)
+        return {
+          ...pokemon,
+          region: region.region,
+          override,
+          pogoApiReleased,
+          effectiveReleased: effective,
+          mismatch: pogoApiReleased !== effective,
+        }
+      })
+    )
+
+    const filtered = values.filter((row) => {
+      if (onlyMismatches && !row.mismatch) return false
+      if (!normalisedQuery) return true
+      return (
+        row.name.toLowerCase().includes(normalisedQuery) ||
+        String(row.dexNumber).includes(normalisedQuery) ||
+        row.region.toLowerCase().includes(normalisedQuery)
+      )
+    })
+
+    return sortPokemonAvailabilityRows(filtered, sort)
+  }, [catalog, overrides, query, sort, onlyMismatches])
+
+  const releasedCount = rows.filter((row) => row.effectiveReleased).length
+  const unreleasedCount = rows.length - releasedCount
+
+  const draftFor = (row) =>
+    drafts[row.dexNumber] || {
+      status: overrideValue(row.override),
+      note: row.override?.note || "",
+    }
+
+  const updateDraft = (dexNumber, changes) => {
+    setDrafts((current) => ({
+      ...current,
+      [dexNumber]: { ...(current[dexNumber] || {}), ...changes },
+    }))
+  }
+
+  const saveOverride = async (row) => {
+    const draft = draftFor(row)
+    setSavingDex(row.dexNumber)
+    setMessage("")
+    try {
+      if (draft.status === "auto") {
+        const response = await fetch(
+          `/api/admin/pokemon-availability-overrides?dexNumber=${row.dexNumber}`,
+          { method: "DELETE" }
+        )
+        if (!response.ok && response.status !== 404) {
+          const data = await response.json()
+          throw new Error(data.error || "Unable to reset override")
+        }
+        setOverrides((current) =>
+          current.filter((override) => override.dexNumber !== row.dexNumber)
+        )
+        setDrafts((current) => {
+          const next = { ...current }
+          delete next[row.dexNumber]
+          return next
+        })
+        setMessage(`${row.name} now follows POGOAPI.`)
+        return
+      }
+
+      const response = await fetch("/api/admin/pokemon-availability-overrides", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dexNumber: row.dexNumber,
+          released: draft.status === "released",
+          note: draft.note || null,
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || "Unable to save override")
+
+      setOverrides((current) => [
+        ...current.filter((override) => override.dexNumber !== row.dexNumber),
+        data.override,
+      ])
+      setDrafts((current) => ({
+        ...current,
+        [row.dexNumber]: {
+          status: overrideValue(data.override),
+          note: data.override.note || "",
+        },
+      }))
+      setMessage(
+        `${row.name} marked ${data.override.released ? "released" : "unreleased"}.`
+      )
+    } catch (saveError) {
+      setMessage(saveError.message)
+    } finally {
+      setSavingDex(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="container">
+        <div className="card">
+          <h1>Pokédex availability</h1>
+          <p>Loading…</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container admin-pokedex-page">
+      <div className="card admin-pokedex-hero">
+        <div>
+          <p><Link href="/admin">← Back to Admin Panel</Link></p>
+          <h1>Pokédex availability overrides</h1>
+          <p className="muted">
+            POGOAPI supplies the default release status. An override wins until
+            it is reset to “Use POGOAPI”.
+          </p>
+          {catalog?.checkedAt && (
+            <p className="muted">
+              POGOAPI last checked: {new Date(catalog.checkedAt).toLocaleString()}
+            </p>
+          )}
+          {message && <p className="status-text">{message}</p>}
+          {error && <p className="status-text">{error}</p>}
+        </div>
+      </div>
+
+      <div className="card admin-pokedex-controls">
+        <label>
+          Search
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Name, number or region"
+          />
+        </label>
+        <label>
+          Sort
+          <select value={sort} onChange={(event) => setSort(event.target.value)}>
+            <option value="unreleased">Unreleased first</option>
+            <option value="released">Released first</option>
+            <option value="dex">National Dex order</option>
+          </select>
+        </label>
+        <label className="admin-pokedex-checkbox">
+          <input
+            type="checkbox"
+            checked={onlyMismatches}
+            onChange={(event) => setOnlyMismatches(event.target.checked)}
+          />
+          Status changes only
+        </label>
+        <p className="muted admin-pokedex-summary">
+          Showing {rows.length}: {releasedCount} released · {unreleasedCount} unreleased
+        </p>
+      </div>
+
+      <div className="admin-pokedex-list">
+        {rows.map((row) => {
+          const draft = draftFor(row)
+          return (
+            <article
+              className={`card admin-pokedex-row ${
+                row.effectiveReleased ? "released" : "unreleased"
+              }`}
+              key={row.dexNumber}
+            >
+              <div className="admin-pokedex-name">
+                <strong>
+                  #{String(row.dexNumber).padStart(3, "0")} {row.name}
+                </strong>
+                <small>{row.region}</small>
+              </div>
+              <div className="admin-pokedex-statuses">
+                <span>
+                  POGOAPI: <strong>{row.pogoApiReleased ? "Released" : "Unreleased"}</strong>
+                </span>
+                <span>
+                  Effective: <strong>{row.effectiveReleased ? "Released" : "Unreleased"}</strong>
+                </span>
+              </div>
+              <label>
+                Override
+                <select
+                  value={draft.status || "auto"}
+                  onChange={(event) =>
+                    updateDraft(row.dexNumber, { status: event.target.value })
+                  }
+                >
+                  <option value="auto">Use POGOAPI</option>
+                  <option value="released">Released</option>
+                  <option value="unreleased">Unreleased</option>
+                </select>
+              </label>
+              <label>
+                Note
+                <input
+                  type="text"
+                  maxLength={500}
+                  value={draft.note || ""}
+                  onChange={(event) =>
+                    updateDraft(row.dexNumber, { note: event.target.value })
+                  }
+                  placeholder="Optional reason"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={() => saveOverride(row)}
+                disabled={savingDex === row.dexNumber}
+              >
+                {savingDex === row.dexNumber ? "Saving…" : "Save"}
+              </button>
+            </article>
+          )
+        })}
+      </div>
+
+      <style jsx>{`
+        .admin-pokedex-page { max-width: 1250px; }
+        .admin-pokedex-hero h1 { margin-bottom: 8px; }
+        .admin-pokedex-controls { display: flex; flex-wrap: wrap; align-items: end; gap: 12px; margin-bottom: 14px; }
+        .admin-pokedex-controls label { display: grid; gap: 5px; font-weight: 700; }
+        .admin-pokedex-controls input[type="search"] { min-width: 260px; }
+        .admin-pokedex-checkbox { grid-auto-flow: column; align-items: center; }
+        .admin-pokedex-summary { margin: 0 0 7px auto; }
+        .admin-pokedex-list { display: grid; gap: 8px; }
+        .admin-pokedex-row { display: grid; grid-template-columns: minmax(180px, 1fr) minmax(220px, 1fr) 160px minmax(180px, 1fr) auto; align-items: end; gap: 10px; padding: 12px; }
+        .admin-pokedex-row.unreleased { border-left: 4px solid #d29922; }
+        .admin-pokedex-row.released { border-left: 4px solid #2ea043; }
+        .admin-pokedex-name { display: grid; gap: 3px; }
+        .admin-pokedex-name small { color: #8b949e; }
+        .admin-pokedex-statuses { display: grid; gap: 3px; font-size: 0.84rem; }
+        .admin-pokedex-row label { display: grid; gap: 4px; font-size: 0.8rem; font-weight: 700; }
+        @media (max-width: 950px) {
+          .admin-pokedex-row { grid-template-columns: 1fr 1fr; }
+          .admin-pokedex-row button { justify-self: start; }
+          .admin-pokedex-summary { width: 100%; margin-left: 0; }
+        }
+        @media (max-width: 600px) {
+          .admin-pokedex-controls, .admin-pokedex-row { display: grid; grid-template-columns: 1fr; }
+          .admin-pokedex-controls input[type="search"] { min-width: 0; width: 100%; }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export async function getServerSideProps(context) {
+  const session = await getServerSession(context.req, context.res, authOptions)
+  if (!session || session.user.role !== "admin") {
+    return { redirect: { destination: "/login", permanent: false } }
+  }
+  return { props: {} }
+}

--- a/pages/api/admin/pokemon-availability-overrides.js
+++ b/pages/api/admin/pokemon-availability-overrides.js
@@ -1,0 +1,86 @@
+import { getServerSession } from "next-auth/next"
+import prisma from "../../../lib/prisma"
+import { authOptions } from "../auth/[...nextauth]"
+
+function parseDexNumber(value) {
+  const dexNumber = Number(value)
+  return Number.isInteger(dexNumber) && dexNumber > 0 ? dexNumber : null
+}
+
+function optionalNote(value) {
+  if (typeof value !== "string") return null
+  const note = value.trim()
+  return note ? note.slice(0, 500) : null
+}
+
+async function requireAdmin(req, res) {
+  const session = await getServerSession(req, res, authOptions)
+  return session?.user?.role === "admin"
+}
+
+export default async function handler(req, res) {
+  if (!(await requireAdmin(req, res))) {
+    res.status(403).json({ error: "Access denied" })
+    return
+  }
+
+  try {
+    if (req.method === "GET") {
+      const overrides = await prisma.pokemonAvailabilityOverride.findMany({
+        orderBy: { dexNumber: "asc" },
+      })
+      res.status(200).json({ overrides })
+      return
+    }
+
+    if (req.method === "PUT") {
+      const dexNumber = parseDexNumber(req.body?.dexNumber)
+      if (!dexNumber || typeof req.body?.released !== "boolean") {
+        res.status(400).json({ error: "A valid Pokédex number and release status are required." })
+        return
+      }
+
+      const override = await prisma.pokemonAvailabilityOverride.upsert({
+        where: { dexNumber },
+        create: {
+          dexNumber,
+          released: req.body.released,
+          note: optionalNote(req.body.note),
+        },
+        update: {
+          released: req.body.released,
+          note: optionalNote(req.body.note),
+        },
+      })
+
+      res.status(200).json({ override, message: "Pokémon availability override saved." })
+      return
+    }
+
+    if (req.method === "DELETE") {
+      const dexNumber = parseDexNumber(req.query.dexNumber)
+      if (!dexNumber) {
+        res.status(400).json({ error: "A valid Pokédex number is required." })
+        return
+      }
+
+      const result = await prisma.pokemonAvailabilityOverride.deleteMany({
+        where: { dexNumber },
+      })
+
+      if (!result.count) {
+        res.status(404).json({ error: "Pokémon availability override not found." })
+        return
+      }
+
+      res.status(200).json({ message: "Pokémon availability override reset." })
+      return
+    }
+
+    res.setHeader("Allow", ["GET", "PUT", "DELETE"])
+    res.status(405).json({ error: "Method not allowed" })
+  } catch (error) {
+    console.error("Pokémon availability override request failed", error)
+    res.status(500).json({ error: "The Pokémon availability override could not be saved." })
+  }
+}

--- a/pages/api/pokedex-catalog.js
+++ b/pages/api/pokedex-catalog.js
@@ -1,5 +1,8 @@
 import { getServerSession } from "next-auth/next"
+import prisma from "../../lib/prisma"
 import { authOptions } from "./auth/[...nextauth]"
+
+const { applyPokemonAvailabilityOverrides } = require("../../lib/pokemonAvailability")
 
 export default async function handler(req, res) {
   if (req.method !== "GET") {
@@ -19,30 +22,41 @@ export default async function handler(req, res) {
     const { getReleasedPokemonData } = require("../../lib/releasedPokemonCache")
     const catalog = await getPokedexCatalogData()
 
+    let pogoApiReleasedDexNumbers = []
     let releasedDexNumbers = []
     let releaseDataStale = false
     let availabilityKnown = true
 
     try {
-      const releasedPokemon = await getReleasedPokemonData()
-      releasedDexNumbers = releasedPokemon.dexNumbers
+      const [releasedPokemon, overrides] = await Promise.all([
+        getReleasedPokemonData(),
+        prisma.pokemonAvailabilityOverride.findMany({
+          select: { dexNumber: true, released: true },
+        }),
+      ])
+      pogoApiReleasedDexNumbers = releasedPokemon.dexNumbers
+      releasedDexNumbers = applyPokemonAvailabilityOverrides(
+        pogoApiReleasedDexNumbers,
+        overrides
+      )
       releaseDataStale = releasedPokemon.stale
     } catch (error) {
       availabilityKnown = false
-      console.error("Unable to load POGOAPI release status for the Pokédex", error)
+      console.error("Unable to load Pokémon release status for the Pokédex", error)
     }
 
-    res.setHeader("Cache-Control", "private, max-age=3600, stale-while-revalidate=86400")
+    res.setHeader("Cache-Control", "private, no-store")
     res.status(200).json({
       ...catalog.data,
+      pogoApiReleasedDexNumbers,
       releasedDexNumbers,
       availabilityKnown,
       stale: catalog.stale || releaseDataStale,
       checkedAt: catalog.checkedAt,
-      source: "POGOAPI",
+      source: "POGOAPI + PvPoke + admin overrides",
     })
   } catch (error) {
-    console.error("Unable to load the POGOAPI Pokédex catalog", error)
+    console.error("Unable to load the Pokédex catalog", error)
     res.status(502).json({
       error: "The Pokédex data is temporarily unavailable. Please try again shortly.",
     })

--- a/pages/pokedex.js
+++ b/pages/pokedex.js
@@ -43,6 +43,11 @@ function PokedexStyles() {
     .pokemon-caught-toggle input { width: 20px; height: 20px; padding: 0; accent-color: #2ea043; }
     .pokemon-caught-toggle input:disabled { cursor: not-allowed; opacity: 0.45; }
     .pokemon-unavailable-note { margin: 0; padding: 8px 10px; border: 1px solid #6e7681; border-radius: 8px; background: rgba(110, 118, 129, 0.12); color: #c9d1d9; font-size: 0.84rem; font-weight: 700; text-align: center; }
+    .pokemon-resource-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+    .pokemon-resource-card { display: grid; gap: 3px; padding: 9px 10px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; }
+    .pokemon-resource-card > span { color: #8b949e; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em; }
+    .pokemon-resource-card strong { color: #f0c36b; font-size: 0.9rem; }
+    .pokemon-resource-card small { color: #c9d1d9; font-size: 0.72rem; }
     .pokemon-evolution-sections { display: grid; gap: 12px; padding-top: 10px; border-top: 1px solid #21262d; }
     .pokemon-evolution-section { display: grid; gap: 7px; }
     .pokemon-evolution-section h4 { margin: 0; color: #c9d1d9; font-size: 0.84rem; }
@@ -67,6 +72,7 @@ function PokedexStyles() {
       .pokemon-card-heading { grid-template-columns: 62px 1fr; }
       .pokemon-card-sprite { width: 62px; height: 62px; }
       .pokemon-caught-toggle { grid-column: 1 / -1; grid-auto-flow: column; justify-content: start; align-items: center; }
+      .pokemon-resource-grid { grid-template-columns: 1fr; }
       .region-meta p { display: none; }
     }
   `}</style>
@@ -92,6 +98,46 @@ function candyCostLabel(candyRequired) {
     return `${Number(candyRequired)} Candy`
   }
   return "Candy cost unavailable"
+}
+
+function formatNumber(value) {
+  return Number(value).toLocaleString()
+}
+
+function PokemonResourceDetails({ details }) {
+  const secondMoveCost = details?.secondMoveCost
+  const buddyDistance = Number(details?.buddyDistance)
+
+  return (
+    <div className="pokemon-resource-grid">
+      <div className="pokemon-resource-card">
+        <span>Second charged move</span>
+        {secondMoveCost ? (
+          <>
+            <strong>{formatNumber(secondMoveCost.stardust)} Stardust</strong>
+            <small>
+              {secondMoveCost.candy === null
+                ? "Candy cost unavailable"
+                : `${formatNumber(secondMoveCost.candy)} Candy`}
+            </small>
+          </>
+        ) : (
+          <strong>Cost unavailable</strong>
+        )}
+      </div>
+      <div className="pokemon-resource-card">
+        <span>Buddy reward</span>
+        {Number.isFinite(buddyDistance) && buddyDistance > 0 ? (
+          <>
+            <strong>{buddyDistance} km</strong>
+            <small>Walk per Candy earned</small>
+          </>
+        ) : (
+          <strong>Distance unavailable</strong>
+        )}
+      </div>
+    </div>
+  )
 }
 
 function EvolutionLink({ relationship, direction, onNavigate }) {
@@ -231,6 +277,7 @@ function PokemonCard({
         </p>
       )}
 
+      <PokemonResourceDetails details={details} />
       <EvolutionStageLinks details={details} onNavigate={onNavigate} />
     </article>
   )
@@ -448,7 +495,7 @@ export default function PokedexPage() {
   }
 
   if (catalogLoading && !catalog) {
-    return <div className="container"><div className="card"><h1>Pokédex</h1><p className="muted">Loading the National Dex from the local POGOAPI cache…</p></div></div>
+    return <div className="container"><div className="card"><h1>Pokédex</h1><p className="muted">Loading the National Dex from the local data cache…</p></div></div>
   }
 
   if (catalogError && !catalog) {
@@ -461,19 +508,19 @@ export default function PokedexPage() {
         <div>
           <h1>Pokédex</h1>
           <p className="muted">
-            Full National Dex grouped by region, with POGOAPI typing, evolution stages, and Candy costs.
+            Full National Dex grouped by region, with typing, evolution costs, second charged-move costs and Buddy Candy distances.
           </p>
           <p className="muted">
             Progress: {caughtCount} / {trackableCount} released Pokémon ({caughtPercentage}%)
           </p>
           {catalog?.stale && (
-            <p className="muted">Using the last locally cached POGOAPI data while an update check is unavailable.</p>
+            <p className="muted">Using the last locally cached data while an update check is unavailable.</p>
           )}
           {catalog && !catalog.availabilityKnown && (
-            <p className="status-text">POGOAPI release status is temporarily unavailable, so availability labels are hidden.</p>
+            <p className="status-text">Release status is temporarily unavailable, so availability labels are hidden.</p>
           )}
           {catalog?.checkedAt && (
-            <p className="muted">POGOAPI hashes last checked: {new Date(catalog.checkedAt).toLocaleString()}</p>
+            <p className="muted">Data hashes last checked: {new Date(catalog.checkedAt).toLocaleString()}</p>
           )}
           {lastSaved && <p className="muted">Last saved: {lastSaved.toLocaleString()}</p>}
         </div>

--- a/prisma/migrations/20260802210000_add_pokemon_availability_override/migration.sql
+++ b/prisma/migrations/20260802210000_add_pokemon_availability_override/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "PokemonAvailabilityOverride" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "dexNumber" INTEGER NOT NULL,
+    "released" BOOLEAN NOT NULL,
+    "note" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PokemonAvailabilityOverride_dexNumber_key" ON "PokemonAvailabilityOverride"("dexNumber");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,15 @@ model PokedexEntry {
   @@unique([ownerId, dexNumber])
 }
 
+model PokemonAvailabilityOverride {
+  id        Int      @id @default(autoincrement())
+  dexNumber Int      @unique
+  released  Boolean
+  note      String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
 model TradeListing {
   id                    Int                 @id @default(autoincrement())
   ownerId               Int


### PR DESCRIPTION
Adds second charged-move Stardust/Candy costs and Buddy Candy distances to Pokémon cards. Adds database-backed Pokémon release-status overrides, an admin editor with unreleased-first sorting, and coverage for the new catalog and sorting logic. Validation PR only; after checks pass the branch will be fast-forwarded onto develop.