### PR TITLE
Validate Pokédex mobile hover fix

### DIFF
--- a/.github/validation/pokedex-hover-fix.txt
+++ b/.github/validation/pokedex-hover-fix.txt
@@ -1,0 +1,1 @@
+Validates the Pokédex mobile hover-state fix from develop.


### PR DESCRIPTION
Temporary validation PR for the final develop tree. Confirms that the Pokédex summary button cannot retain the global green hover state after a mobile tap. This PR will be closed without merge and its branch deleted after both validation workflows pass.