### PR TITLE
Validate explicit Pokédex regional locks

### DIFF
--- a/.github/regional-checkbox-validation.txt
+++ b/.github/regional-checkbox-validation.txt
@@ -1,0 +1,1 @@
+Temporary validation marker for explicit Pokédex regional lock checkboxes.

--- a/.github/workflows/validate-regional-checkboxes.yml
+++ b/.github/workflows/validate-regional-checkboxes.yml
@@ -1,0 +1,44 @@
+name: Validate regional lock checkboxes
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  lint-test-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DATABASE_URL: file:./validation.db
+      NEXTAUTH_SECRET: validation-only-secret
+      NEXTAUTH_URL: http://localhost:3000
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --runInBand --passWithNoTests
+
+      - name: Production build
+        run: npm run build
+        env:
+          NODE_ENV: production


### PR DESCRIPTION
Temporary validation PR for the explicit regional lock checkboxes added directly to develop. This runs the repository lint, complete Jest suite, dependency audits and production build. It will be closed without merge after validation.